### PR TITLE
increase load balancer idle timeout

### DIFF
--- a/cicd/3-app/aiproxy/template.yml
+++ b/cicd/3-app/aiproxy/template.yml
@@ -60,6 +60,9 @@ Resources:
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: 180
       SecurityGroups:
         - !ImportValue VPC-ELBSecurityGroup
       Subnets:


### PR DESCRIPTION
Requests to OpenAI can take 65+ seconds. Setting a 3 minute timeout here, the client calling this service will likely set it's own shorter timout.