### PR TITLE
show better errors when openai returns invalid response

### DIFF
--- a/lib/assessment/grade.py
+++ b/lib/assessment/grade.py
@@ -186,11 +186,15 @@ class Grade:
             raise InvalidResponseError('invalid format')
 
         if not all((set(row.keys()) & set(expected_columns)) == set(expected_columns) for row in tsv_data):
-            raise InvalidResponseError('incorrect column names')
+            unexpected_columns = set(row.keys()) - set(expected_columns)
+            missing_columns = set(expected_columns) - set(row.keys())
+            raise InvalidResponseError('incorrect column names. unexpected: {unexpected_columns} missing: {missing_columns}')
 
         key_concepts_from_response = list(set(row["Key Concept"] for row in tsv_data))
         if sorted(rubric_key_concepts) != sorted(key_concepts_from_response):
-            raise InvalidResponseError('invalid or missing key concept')
+            unexpected_concepts = set(key_concepts_from_response) - set(rubric_key_concepts)
+            missing_concepts = set(rubric_key_concepts) - set(key_concepts_from_response)
+            raise InvalidResponseError(f'unexpected or missing key concept. unexpected: {unexpected_concepts} missing: {missing_concepts}')
 
         for row in tsv_data:
             if row["Grade"] not in VALID_GRADES:

--- a/lib/assessment/grade.py
+++ b/lib/assessment/grade.py
@@ -56,15 +56,7 @@ class Grade:
         elapsed = time.time() - start_time
         logging.info(f"{student_id} request succeeded in {elapsed:.0f} seconds. {tokens} tokens used.")
 
-        tsv_data_choices = [self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index) for index, choice in enumerate(info['choices']) if choice['message']['content']]
-        tsv_data_choices = [choice for choice in tsv_data_choices if choice]
-
-        if len(tsv_data_choices) == 0:
-            tsv_data = None
-        elif len(tsv_data_choices) == 1:
-            tsv_data = tsv_data_choices[0]
-        else:
-            tsv_data = self.get_consensus_response(tsv_data_choices, student_id)
+        tsv_data = self.tsv_data_from_choices(info, rubric, student_id)
 
         # only write to cache if the response is valid
         if write_cached and tsv_data:
@@ -80,6 +72,19 @@ class Grade:
             },
             'data': tsv_data,
         }
+
+    def tsv_data_from_choices(self, info, rubric, student_id):
+        tsv_data_choices = [
+            self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index) for
+            index, choice in enumerate(info['choices']) if choice['message']['content']]
+        tsv_data_choices = [choice for choice in tsv_data_choices if choice]
+        if len(tsv_data_choices) == 0:
+            tsv_data = None
+        elif len(tsv_data_choices) == 1:
+            tsv_data = tsv_data_choices[0]
+        else:
+            tsv_data = self.get_consensus_response(tsv_data_choices, student_id)
+        return tsv_data
 
     def sanitize_code(self, student_code, remove_comments=False):
         # Remove comments

--- a/lib/assessment/grade.py
+++ b/lib/assessment/grade.py
@@ -86,7 +86,7 @@ class Grade:
                     tsv_data_choices.append(tsv_data)
 
         if len(tsv_data_choices) == 0:
-            tsv_data = None
+            raise "No valid responses. An InvalidResponseError should have been raised earlier."
         elif len(tsv_data_choices) == 1:
             tsv_data = tsv_data_choices[0]
         else:
@@ -207,7 +207,9 @@ class Grade:
         key_concepts_from_response = list(set(row["Key Concept"] for row in tsv_data))
         if sorted(rubric_key_concepts) != sorted(key_concepts_from_response):
             unexpected_concepts = set(key_concepts_from_response) - set(rubric_key_concepts)
+            unexpected_concepts = None if len(unexpected_concepts) == 0 else unexpected_concepts
             missing_concepts = set(rubric_key_concepts) - set(key_concepts_from_response)
+            missing_concepts = None if len(missing_concepts) == 0 else missing_concepts
             raise InvalidResponseError(f'unexpected or missing key concept. unexpected: {unexpected_concepts} missing: {missing_concepts}')
 
         for row in tsv_data:

--- a/lib/assessment/grade.py
+++ b/lib/assessment/grade.py
@@ -74,8 +74,9 @@ class Grade:
         }
 
     def tsv_data_from_choices(self, info, rubric, student_id):
+        max_index = len(info['choices']) - 1
         tsv_data_choices = [
-            self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index) for
+            self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index, max_index=max_index) for
             index, choice in enumerate(info['choices']) if choice['message']['content']]
         tsv_data_choices = [choice for choice in tsv_data_choices if choice]
         if len(tsv_data_choices) == 0:
@@ -110,7 +111,7 @@ class Grade:
         messages.append({'role': 'user', 'content': student_code})
         return messages
 
-    def get_tsv_data_if_valid(self, response_text, rubric, student_id, choice_index=None):
+    def get_tsv_data_if_valid(self, response_text, rubric, student_id, choice_index=None, max_index=None):
         choice_text = f"Choice {choice_index}: " if choice_index is not None else ''
         if not response_text:
             logging.error(f"{student_id} {choice_text} Invalid response: empty response")
@@ -154,6 +155,8 @@ class Grade:
             return [row for row in tsv_data]
         except InvalidResponseError as e:
             logging.error(f"{student_id} {choice_text} Invalid response: {str(e)}\n{response_text}")
+            if choice_index == max_index:
+                raise e
             return None
 
     def parse_tsv(self, tsv_text):

--- a/lib/assessment/grade.py
+++ b/lib/assessment/grade.py
@@ -73,6 +73,20 @@ class Grade:
             'data': tsv_data,
         }
 
+    def sanitize_code(self, student_code, remove_comments=False):
+        # Remove comments
+        if remove_comments:
+            student_code = "\n".join(
+                list(
+                    map(lambda x:
+                        x[0:x.index("//")] if "//" in x else x,
+                        student_code.split('\n')
+                    )
+                )
+            )
+
+        return student_code
+
     def tsv_data_from_choices(self, info, rubric, student_id):
         max_index = len(info['choices']) - 1
         tsv_data_choices = []
@@ -92,20 +106,6 @@ class Grade:
         else:
             tsv_data = self.get_consensus_response(tsv_data_choices, student_id)
         return tsv_data
-
-    def sanitize_code(self, student_code, remove_comments=False):
-        # Remove comments
-        if remove_comments:
-            student_code = "\n".join(
-                list(
-                    map(lambda x:
-                        x[0:x.index("//")] if "//" in x else x,
-                        student_code.split('\n')
-                    )
-                )
-            )
-
-        return student_code
 
     def compute_messages(self, prompt, rubric, student_code, examples=[]):
         messages = [

--- a/src/assessment.py
+++ b/src/assessment.py
@@ -53,7 +53,7 @@ def post_assessment():
     except openai.error.InvalidRequestError as e:
         return str(e), 400
     except InvalidResponseError as e:
-        return str(e), 400
+        return f'InvalidResponseError: {str(e)}', 400
 
     if not isinstance(grades, dict) and isinstance(grades.get("data"), list):
         return "response from AI or service not valid", 400

--- a/src/assessment.py
+++ b/src/assessment.py
@@ -9,6 +9,7 @@ import json
 
 # Our assessment code
 from lib.assessment import assess
+from lib.assessment.grade import InvalidResponseError
 
 assessment_routes = Blueprint('assessment_routes', __name__)
 
@@ -50,6 +51,8 @@ def post_assessment():
     except ValueError:
         return "One of the arguments is not parseable as a number", 400
     except openai.error.InvalidRequestError as e:
+        return str(e), 400
+    except InvalidResponseError as e:
         return str(e), 400
 
     if not isinstance(grades, dict) and isinstance(grades.get("data"), list):


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-286. Today, we have a bunch of validation checks to make sure the response we get from openai is correct, but we do not include a lot of error details and you have to go to the aiproxy logs to find them.

### before
First you would go look at the dashboard logs:
```
Error performing EvaluateRubricJob (Job ID: 2782adbf-83d6-4752-9951-b7bd7d326ccd) from DelayedJob(default) in 53262.29ms: NoMethodError (undefined method `map' for nil:NilClass):
/Users/dsb/src/cdo/dashboard/app/jobs/evaluate_rubric_job.rb:146:in `validate_evaluations'
/Users/dsb/src/cdo/dashboard/app/jobs/evaluate_rubric_job.rb:50:in `perform'
```

Since these are not helpful, you would next have to check the ai proxy logs. 
```
aiproxy-python-proxy-1  | 2023-10-27 03:57:26,390: root:student Choice 0:  Invalid response: invalid or missing key concept
```

Note that the `invalid or missing key concept`  doesn't say which concept, so next you have to look through the wall of text which follows, and compare it against the standard_rubric.csv, to see what looks off:
```
aiproxy-python-proxy-1  | Key Concept	Observations	Grade	Reason
aiproxy-python-proxy-1  | Modularity - Multiple Sprites	Three sprites are created: moving_crutch, bunny, and stable_crutch. The properties moving_crutch.x, moving_crutch.rotation are updated inside the draw loop.	Convincing Evidence	Three sprites are created and each has at least one property that is updated in the draw loop.
aiproxy-python-proxy-1  | Algorithms and Control - User Input	The program checks for user input with keyWentDown("right") and keyWentDown("left"). When the user presses the right arrow key, the moving_crutch sprite moves to the right and rotates randomly. When the user presses the left arrow key, the moving_crutch sprite moves to the left and rotates randomly.	Extensive Evidence	The program responds to two different types of user input: the right and left arrow keys.
aiproxy-python-proxy-1  | Algorithms and Control - Conditionals	(1) Conditionals in draw loop: keyWentDown("right"), keyWentDown("left"). (2) Conditionals responding to user input: keyWentDown("right"), keyWentDown("left"). (3) Conditionals predicated on sprite property: none.	Limited Evidence	The program uses 2 conditionals inside the draw loop that all respond to user input.
aiproxy-python-proxy-1  | Position and Movement	The sprites moving_crutch, bunny, and stable_crutch are placed on the screen. The moving_crutch sprite moves left or right based on user input and rotates randomly.	Convincing Evidence	Three sprites are placed on the screen using the coordinate system. One of the sprites moves during the program.
```

#### after
Now you can see which key concepts are either unexpected or missing in the dashboard logs:
```
Error performing EvaluateRubricJob (Job ID: 22fe7924-3d97-4fb3-9ecb-e727514be328) from DelayedJob(default) in 40461.71ms: RuntimeError (ERROR: 400 BAD REQUEST InvalidResponseError: unexpected or missing key concept. unexpected: {'Modularity - Multiple Sprites'} missing: None):
/Users/dsb/src/cdo/dashboard/app/jobs/evaluate_rubric_job.rb:139:in `get_openai_evaluations'
/Users/dsb/src/cdo/dashboard/app/jobs/evaluate_rubric_job.rb:48:in `perform'
```
If you insist on also checking the ai proxy logs, you can see the same helpful error details there too:
```
aiproxy-python-proxy-1  | 2023-10-27 04:04:10,661: root:student Choice 0:  Invalid response: unexpected or missing key concept. unexpected: {'Modularity - Multiple Sprites'} missing: None
```

## Testing story

no unit tests yet, so I tested this locally as follows:
* created a [separate path in s3](https://s3.console.aws.amazon.com/s3/buckets/cdo-ai?region=us-east-1&prefix=teaching_assistant/lessons-dave/CSD-2022-U3-L17/) with some bad lesson config in it, which causes openai to consistently give invalid results
* temporarily pointed my local dashboard server at the new s3 directory to generate the above output
* pointed dashboard back to the normal lesson directory and verified that the good path is still working