### PR TITLE
Ceara/aitt 405 rename ml variables

### DIFF
--- a/lib/assessment/assess.py
+++ b/lib/assessment/assess.py
@@ -9,18 +9,6 @@ import logging
 # Import our support classes
 from lib.assessment.config import SUPPORTED_MODELS, VALID_GRADES
 from lib.assessment.grade import Grade
-from lib.assessment.report import Report
-from lib.assessment.rubric_tester import (
-    read_inputs,
-    get_expected_grades,
-    get_examples,
-    get_passing_grades,
-    get_student_files,
-    validate_rubrics,
-    validate_students,
-    grade_student_work,
-    compute_accuracy
-)
 
 class KeyConceptError(Exception):
   pass

--- a/lib/assessment/assess.py
+++ b/lib/assessment/assess.py
@@ -7,7 +7,7 @@ import json
 import logging
 
 # Import our support classes
-from lib.assessment.config import SUPPORTED_MODELS, VALID_GRADES
+from lib.assessment.config import SUPPORTED_MODELS, VALID_LABELS
 from lib.assessment.grade import Grade
 
 class KeyConceptError(Exception):

--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -1,4 +1,4 @@
-VALID_GRADES = ["Extensive Evidence", "Convincing Evidence", "Limited Evidence", "No Evidence"]
+VALID_LABELS = ["Extensive Evidence", "Convincing Evidence", "Limited Evidence", "No Evidence"]
 SUPPORTED_MODELS = ['gpt-4', 'gpt-4-0314', 'gpt-4-32k', 'gpt-4-32k-0314']
 LESSONS = {
     "U3-2022-L10" : "1ROCbvHb3yWGVoQqzKAjwdaF0dSRPUjy_",

--- a/lib/assessment/grade.py
+++ b/lib/assessment/grade.py
@@ -7,7 +7,7 @@ import requests
 import logging
 
 from typing import List, Dict, Any
-from lib.assessment.config import VALID_GRADES
+from lib.assessment.config import VALID_LABELS
 
 from io import StringIO
 
@@ -274,7 +274,7 @@ class Grade:
             raise InvalidResponseError(f'unexpected or missing key concept. unexpected: {unexpected_concepts} missing: {missing_concepts}')
 
         for row in tsv_data:
-            if row["Grade"] not in VALID_GRADES:
+            if row["Grade"] not in VALID_LABELS:
                 raise InvalidResponseError(f"invalid grade value: '{row['Grade']}'")
 
     def get_consensus_response(self, choices, student_id):

--- a/lib/assessment/grade.py
+++ b/lib/assessment/grade.py
@@ -22,7 +22,7 @@ class Grade:
     #
     # For instance, it will determine a blank project should receive a No Evidence score for
     # all items in the rubric.
-    def statically_grade_student_work(self, rubric, student_code, student_id, examples=[]):
+    def statically_label_student_work(self, rubric, student_code, student_id, examples=[]):
         rubric_key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
         if student_code.strip() == "":
@@ -47,7 +47,7 @@ class Grade:
         # We can't assess this statically
         return None
 
-    def ai_grade_student_work(self, prompt, rubric, student_code, student_id, examples=[], num_responses=0, temperature=0.0, llm_model=""):
+    def ai_label_student_work(self, prompt, rubric, student_code, student_id, examples=[], num_responses=0, temperature=0.0, llm_model=""):
         # Determine the OpenAI URL and headers
         api_url = 'https://api.openai.com/v1/chat/completions'
         headers = {
@@ -97,14 +97,14 @@ class Grade:
         student_code = self.sanitize_code(student_code, remove_comments=remove_comments)
 
         # Try static analysis options (before invoking AI)
-        result = self.statically_grade_student_work(rubric, student_code, student_id, examples=examples)
+        result = self.statically_label_student_work(rubric, student_code, student_id, examples=examples)
 
         # If it gives back a response, right now assume it is complete and do not perform an AI analysis
-        # We may want to, in the future, gauge how many of the concepts it has graded and let AI fill in the blanks
+        # We may want to, in the future, gauge how many of the concepts it has labeled and let AI fill in the blanks
         # Right now, however, only if there is no result, we try the AI for assessment
         if result is None:
             try:
-                result = self.ai_grade_student_work(prompt, rubric, student_code, student_id, examples=examples, num_responses=num_responses, temperature=temperature, llm_model=llm_model)
+                result = self.ai_label_student_work(prompt, rubric, student_code, student_id, examples=examples, num_responses=num_responses, temperature=temperature, llm_model=llm_model)
             except requests.exceptions.ReadTimeout:
                 logging.error(f"{student_id} request timed out in {(time.time() - start_time):.0f} seconds.")
                 result = None
@@ -275,33 +275,33 @@ class Grade:
 
         for row in tsv_data:
             if row["Grade"] not in VALID_LABELS:
-                raise InvalidResponseError(f"invalid grade value: '{row['Grade']}'")
+                raise InvalidResponseError(f"invalid label value: '{row['Grade']}'")
 
     def get_consensus_response(self, choices, student_id):
         from collections import Counter
 
-        key_concept_to_grades = {}
+        key_concept_to_labels = {}
         for choice in choices:
             for row in choice:
-                if row['Key Concept'] not in key_concept_to_grades:
-                    key_concept_to_grades[row['Key Concept']] = []
-                key_concept_to_grades[row['Key Concept']].append(row['Grade'])
+                if row['Key Concept'] not in key_concept_to_labels:
+                    key_concept_to_labels[row['Key Concept']] = []
+                key_concept_to_labels[row['Key Concept']].append(row['Grade'])
 
-        key_concept_to_majority_grade = {}
-        for key_concept, grades in key_concept_to_grades.items():
-            majority_grade = Counter(grades).most_common(1)[0][0]
-            key_concept_to_majority_grade[key_concept] = majority_grade
-            if majority_grade != grades[0]:
-                logging.info(f"outvoted {student_id} Key Concept: {key_concept} first grade: {grades[0]} majority grade: {majority_grade}")
+        key_concept_to_majority_label = {}
+        for key_concept, labels in key_concept_to_labels.items():
+            majority_label = Counter(labels).most_common(1)[0][0]
+            key_concept_to_majority_label[key_concept] = majority_label
+            if majority_label != labels[0]:
+                logging.info(f"outvoted {student_id} Key Concept: {key_concept} first label: {labels[0]} majority label: {majority_label}")
 
         key_concept_to_observations = {}
         key_concept_to_reason = {}
         for choice in choices:
             for row in choice:
                 key_concept = row['Key Concept']
-                if key_concept_to_majority_grade[key_concept] == row['Grade']:
+                if key_concept_to_majority_label[key_concept] == row['Grade']:
                     if key_concept not in key_concept_to_observations:
                         key_concept_to_observations[key_concept] = row['Observations']
                     key_concept_to_reason[key_concept] = row['Reason']
 
-        return [{'Key Concept': key_concept, 'Observations': key_concept_to_observations[key_concept], 'Grade': grade, 'Reason': f"<b>Votes: [{', '.join(key_concept_to_grades[key_concept])}]</b><br>{key_concept_to_reason[key_concept]}"} for key_concept, grade in key_concept_to_majority_grade.items()]
+        return [{'Key Concept': key_concept, 'Observations': key_concept_to_observations[key_concept], 'Grade': label, 'Reason': f"<b>Votes: [{', '.join(key_concept_to_labels[key_concept])}]</b><br>{key_concept_to_reason[key_concept]}"} for key_concept, label in key_concept_to_majority_label.items()]

--- a/lib/assessment/report.py
+++ b/lib/assessment/report.py
@@ -3,25 +3,25 @@ import csv
 import io
 import json
 from typing import List, Dict, Any
-from lib.assessment.config import VALID_GRADES
+from lib.assessment.config import VALID_LABELS
 
 class Report:
-    def _compute_pass_fail_cell_color(self, actual, predicted, passing_grades):
-        if Report.accurate(actual, predicted, passing_grades):
+    def _compute_pass_fail_cell_color(self, actual, predicted, passing_labels):
+        if Report.accurate(actual, predicted, passing_labels):
             return 'green'
         else:
             return 'red'
 
-    def _compute_predicted_cell_color(self, predicted, actual, passing_grades):
-        if passing_grades:
-            return self._compute_pass_fail_cell_color(actual, predicted, passing_grades)
+    def _compute_predicted_cell_color(self, predicted, actual, passing_labels):
+        if passing_labels:
+            return self._compute_pass_fail_cell_color(actual, predicted, passing_labels)
 
-        actual_index = VALID_GRADES.index(actual) if actual in VALID_GRADES else None
-        predicted_index = VALID_GRADES.index(predicted) if predicted in VALID_GRADES else None
-        grade_difference = abs(actual_index - predicted_index) if actual_index is not None and predicted_index is not None else None
-        if grade_difference == 0:
+        actual_index = VALID_LABELS.index(actual) if actual in VALID_LABELS else None
+        predicted_index = VALID_LABELS.index(predicted) if predicted in VALID_LABELS else None
+        label_difference = abs(actual_index - predicted_index) if actual_index is not None and predicted_index is not None else None
+        if label_difference == 0:
             return 'green'
-        elif grade_difference == 1:
+        elif label_difference == 1:
             return 'yellow'
         else:
             return 'red'
@@ -82,7 +82,7 @@ class Report:
         confusion_table += '</table>'
         return confusion_table
 
-    def generate_html_output(self, output_file, prompt, rubric, accuracy=None, predicted_grades=None, actual_grades=None, passing_grades=None, accuracy_by_criteria=None, errors=[], command_line=None, confusion_by_criteria=None, overall_confusion=None, grade_names=None, prefix='sample_code'):
+    def generate_html_output(self, output_file, prompt, rubric, accuracy=None, predicted_labels=None, actual_labels=None, passing_labels=None, accuracy_by_criteria=None, errors=[], command_line=None, confusion_by_criteria=None, overall_confusion=None, label_names=None, prefix='sample_code'):
         link_base_url = f'file://{os.getcwd()}/{prefix}'
 
         with open(output_file, 'w+') as file:
@@ -113,30 +113,30 @@ class Report:
                 file.write('  <h2>Accuracy by Key Concept:</h2>\n')
                 file.write(self._generate_accuracy_table(accuracy_by_criteria) + '\n')
 
-            if overall_confusion is not None and grade_names is not None:
+            if overall_confusion is not None and label_names is not None:
                 file.write('  <h2>Overall Confusion:</h2>\n')
-                file.write(self._generate_confusion_table(overall_confusion, grade_names) + '\n')
+                file.write(self._generate_confusion_table(overall_confusion, label_names) + '\n')
 
-            if confusion_by_criteria is not None and grade_names is not None:
+            if confusion_by_criteria is not None and label_names is not None:
                 file.write('  <h2>Confusion by Key Concept:</h2>\n')
                 for criteria in confusion_by_criteria:
                     file.write(f'  <h3>Confusion for {criteria}:</h3>\n')
-                    file.write(self._generate_confusion_table(confusion_by_criteria[criteria], grade_names) + '\n\n')
+                    file.write(self._generate_confusion_table(confusion_by_criteria[criteria], label_names) + '\n\n')
 
-            if predicted_grades is not None:
-                file.write('  <h2>Grades by student:</h2>\n')
-                for student_id, grades in predicted_grades.items():
+            if predicted_labels is not None:
+                file.write('  <h2>Labels by student:</h2>\n')
+                for student_id, labels in predicted_labels.items():
                     file.write(f'  <h3>Student: {student_id}</h3>\n')
                     file.write(f'  <a href="{link_base_url}/{student_id}.js">{student_id}.js</a>\n')
                     file.write('  <table border="1">\n')
-                    file.write('    <tr><th>Criteria</th><th>Observations</th><th>Actual Grade (human)</th><th>Predicted Grade (AI)</th><th>Reason</th></tr>\n')
-                    for grade in grades:
-                        criteria = grade['Key Concept']
-                        observations = grade['Observations']
-                        actual = actual_grades[student_id][criteria]
-                        predicted = grade['Grade']
-                        reason = grade['Reason']
-                        cell_color = self._compute_predicted_cell_color(predicted, actual, passing_grades)
+                    file.write('    <tr><th>Criteria</th><th>Observations</th><th>Actual Label (human)</th><th>Predicted Label (AI)</th><th>Reason</th></tr>\n')
+                    for label in labels:
+                        criteria = label['Key Concept']
+                        observations = label['Observations']
+                        actual = actual_labels[student_id][criteria]
+                        predicted = label['Grade']
+                        reason = label['Reason']
+                        cell_color = self._compute_predicted_cell_color(predicted, actual, passing_labels)
                         file.write(f'    <tr><td>{criteria}</td><td>{observations}</td><td>{actual}</td><td style="background-color: {cell_color};">{predicted}</td><td>{reason}</td></tr>\n')
                     file.write('  </table>\n')
 
@@ -144,8 +144,8 @@ class Report:
             file.write('</html>\n')
 
     @staticmethod
-    def accurate(actual_grade, predicted_grade, passing_grades):
-        if passing_grades:
-            return passing_grades.count(actual_grade) == passing_grades.count(predicted_grade)
+    def accurate(actual_label, predicted_label, passing_labels):
+        if passing_labels:
+            return passing_labels.count(actual_label) == passing_labels.count(predicted_label)
         else:
-            return actual_grade == predicted_grade
+            return actual_label == predicted_label

--- a/tests/unit/assessment/conftest.py
+++ b/tests/unit/assessment/conftest.py
@@ -7,8 +7,8 @@ import pytest
 
 
 @pytest.fixture
-def random_grade_generator():
-    def gen_random_grade():
+def random_label_generator():
+    def gen_random_label():
         return random.choice([
             'Extensive Evidence',
             'Convincing Evidence',
@@ -16,7 +16,7 @@ def random_grade_generator():
             'No Evidence'
         ])
 
-    yield gen_random_grade
+    yield gen_random_label
 
 
 @pytest.fixture
@@ -76,19 +76,19 @@ def rubric(randomstring):
 
 
 @pytest.fixture
-def example_generator(code, randomstring, random_grade_generator):
+def example_generator(code, randomstring, random_label_generator):
     """ Creates a random example.
     """
 
     def gen_example(rubric):
-        # Generate the example grades (which are TSV formatted)
+        # Generate the example labels (which are TSV formatted)
         example_rubric = "Key Concept\tObservations\tGrade\tReason\n"
 
-        # Generate a grade for each concept
+        # Generate a label for each concept
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
         example_rubric += '\n'.join(
             map(
-                lambda key_concept: f'{key_concept}\t{randomstring(10)}\t{random_grade_generator()}\t{randomstring(12)}',
+                lambda key_concept: f'{key_concept}\t{randomstring(10)}\t{random_label_generator()}\t{randomstring(12)}',
                 set(x['Key Concept'] for x in parsed_rubric)
             )
         )
@@ -183,8 +183,8 @@ def openai_gpt_response(randomstring):
         def gen_rubric_response_header(delimiter='\t'):
             return f"Key Concept{delimiter}Observations{delimiter}Grade{delimiter}Reason\n"
 
-        def gen_rubric_response_row(key_concept, grade, delimiter='\t'):
-            return f"{key_concept}{delimiter}{randomstring(10)}{delimiter}{grade}{delimiter}{randomstring(10)}\n"
+        def gen_rubric_response_row(key_concept, label, delimiter='\t'):
+            return f"{key_concept}{delimiter}{randomstring(10)}{delimiter}{label}{delimiter}{randomstring(10)}\n"
 
         delimiter = '\t'
 
@@ -194,9 +194,9 @@ def openai_gpt_response(randomstring):
         if output_type == 'csv':
             delimiter = ','
 
-        assigned_grades = {}
+        assigned_labels = {}
         for key_concept in key_concepts:
-            assigned_grades[key_concept] = random.choice([
+            assigned_labels[key_concept] = random.choice([
                 'Extensive Evidence',
                 'Convincing Evidence',
                 'Limited Evidence',
@@ -208,19 +208,19 @@ def openai_gpt_response(randomstring):
             content = gen_rubric_response_header(delimiter)
 
             for key_concept in key_concepts:
-                grade = assigned_grades[key_concept]
+                label = assigned_labels[key_concept]
 
                 # Add a disagreement, if requested
                 if disagreements_left != 0:
-                    grade = random.choice(list(set([
+                    label = random.choice(list(set([
                         'Extensive Evidence',
                         'Convincing Evidence',
                         'Limited Evidence',
                         'No Evidence'
-                    ]) - set([grade])))
+                    ]) - set([label])))
                     disagreements_left -= 1
 
-                content += gen_rubric_response_row(key_concept, grade, delimiter)
+                content += gen_rubric_response_row(key_concept, label, delimiter)
 
             gpt_response['choices'].append({
                 'index': i,

--- a/tests/unit/assessment/test_report.py
+++ b/tests/unit/assessment/test_report.py
@@ -15,25 +15,25 @@ def report():
 
 
 class TestAccurate:
-    def test_should_just_match_expected_to_actual_if_no_passing_grades(self):
+    def test_should_just_match_actual_to_predicted_if_no_passing_grades(self):
         assert Report.accurate('No Evidence', 'No Evidence', None)
 
-    def test_should_return_false_when_expected_is_not_actual_if_no_passing_grades(self):
+    def test_should_return_false_when_actual_is_not_predicted_if_no_passing_grades(self):
         assert Report.accurate('No Evidence', 'Limited Evidence', None) == False
 
     def test_should_count_equal_number_of_matching_grades_in_given_passing_grades(self):
         assert Report.accurate('Convincing Evidence', 'Convincing Evidence', ['Convincing Evidence', 'Extensive Evidence'])
 
-    def test_should_be_true_when_expected_not_matching_actual_but_both_in_given_passing_grades(self):
+    def test_should_be_true_when_actual_not_matching_predicted_but_both_in_given_passing_grades(self):
         assert Report.accurate('Convincing Evidence', 'Extensive Evidence', ['Convincing Evidence', 'Extensive Evidence'])
 
     def test_should_return_true_when_neither_are_in_set_of_passing_grades(self):
         assert Report.accurate('No Evidence', 'Limited Evidence', ['Convincing Evidence', 'Extensive Evidence'])
 
-    def test_should_return_false_when_expected_is_not_in_set_of_passing_grades(self):
+    def test_should_return_false_when_actual_is_not_in_set_of_passing_grades(self):
         assert Report.accurate('No Evidence', 'Convincing Evidence', ['Convincing Evidence', 'Extensive Evidence']) == False
 
-    def test_should_return_false_when_actual_is_not_in_set_of_passing_grades(self):
+    def test_should_return_false_when_predicted_is_not_in_set_of_passing_grades(self):
         assert Report.accurate('Convincing Evidence', 'No Evidence', ['Convincing Evidence', 'Extensive Evidence']) == False
 
 
@@ -61,7 +61,14 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            accuracy="42",
+            command_line="./assess.py",
+        )
 
         mock_file.assert_called_with(output_file, 'w+')
 
@@ -73,7 +80,14 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            accuracy="42",
+            command_line="./assess.py",
+        )
 
         output = self._get_output(mock_file)
 
@@ -89,7 +103,14 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            accuracy="42",
+            command_line="./assess.py",
+        )
 
         output = self._get_output(mock_file)
 
@@ -106,7 +127,13 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, [], "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            command_line="./assess.py",
+        )
 
         output = self._get_output(mock_file)
 
@@ -136,7 +163,14 @@ class TestGenerateHtmlOutput:
             else:
                 accuracy_by_criteria[key_concept] = random.randint(0, 100)
 
-        report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], accuracy_by_criteria, [], "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], accuracy_by_criteria, [], "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            accuracy_by_criteria=accuracy_by_criteria,
+            command_line="./assess.py",
+        )
 
         output = self._get_output(mock_file)
 
@@ -155,18 +189,28 @@ class TestGenerateHtmlOutput:
         confusion_by_criteria = {}
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
         key_concepts = [x['Key Concept'] for x in parsed_rubric]
+        overall_confusion = []
+        for g in grades:
+            overall_confusion.append(random.sample(range(0, 100), len(grades)))
         for key_concept in key_concepts:
             confusion_by_criteria[key_concept] = []
             for g in grades:
                 confusion_by_criteria[key_concept].append(random.sample(range(0, 100), len(grades)))
 
-        report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, [], "./assess.py", confusion_by_criteria, [], grades)
+        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, [], "./assess.py", confusion_by_criteria, [], grades)
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            command_line="./assess.py",
+            overall_confusion=overall_confusion,
+            confusion_by_criteria=confusion_by_criteria,
+            grade_names=grades,
+        )
 
-        print(confusion_by_criteria)
         output = self._get_output(mock_file)
 
-        print()
-        print(output)
+        assert re.search(fr'<h2>Overall Confusion:</h2>.*style="text-align: center">{overall_confusion[0][0]}<', output)
         for key_concept in key_concepts:
             assert re.search(fr'<h3>Confusion for {key_concept}:</h3>.*style="text-align: center">{confusion_by_criteria[key_concept][0][0]}<', output)
 
@@ -178,14 +222,14 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
+        predicted_grades = {}
         actual_grades = {}
-        expected_grades = {}
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
         key_concepts = [x['Key Concept'] for x in parsed_rubric]
         for _ in range(1, random.randint(3, 10)):
             student_id = str(random.randint(100000, 999999))
 
-            actual_grades[student_id] = list(map(lambda key_concept:
+            predicted_grades[student_id] = list(map(lambda key_concept:
                 {
                     'Key Concept': key_concept,
                     'Observations': 'What I see',
@@ -196,18 +240,26 @@ class TestGenerateHtmlOutput:
             ))
 
             for key_concept in key_concepts:
-                expected_grades[student_id] = expected_grades.get(student_id, {})
-                expected_grades[student_id][key_concept] = random_grade_generator()
+                actual_grades[student_id] = actual_grades.get(student_id, {})
+                actual_grades[student_id][key_concept] = random_grade_generator()
 
-        report.generate_html_output(output_file, prompt, rubric, None, actual_grades, expected_grades, [], {}, [], "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, None, predicted_grades, actual_grades, [], {}, [], "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            predicted_grades=predicted_grades,
+            actual_grades=actual_grades,
+            command_line="./assess.py",
+        )
 
         output = self._get_output(mock_file)
 
-        for student_id, grades in actual_grades.items():
+        for student_id, grades in predicted_grades.items():
             for grade in grades:
                 key_concept = grade['Key Concept']
 
-                assert re.search(fr'<td>{key_concept}</td>.*>{expected_grades[student_id][key_concept]}<', output)
+                assert re.search(fr'<td>{key_concept}</td>.*>{actual_grades[student_id][key_concept]}<', output)
                 assert re.search(fr'<td>{key_concept}</td>.*>{grade["Grade"]}<', output)
 
     def test_should_report_generated_grade_report_with_pass_fail(self, mocker, report, prompt, rubric, random_grade_generator, randomstring):
@@ -218,14 +270,14 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
+        predicted_grades = {}
         actual_grades = {}
-        expected_grades = {}
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
         key_concepts = [x['Key Concept'] for x in parsed_rubric]
         for _ in range(1, random.randint(3, 10)):
             student_id = str(random.randint(100000, 999999))
 
-            actual_grades[student_id] = list(map(lambda key_concept:
+            predicted_grades[student_id] = list(map(lambda key_concept:
                 {
                     'Key Concept': key_concept,
                     'Observations': 'What I see',
@@ -236,19 +288,28 @@ class TestGenerateHtmlOutput:
             ))
 
             for key_concept in key_concepts:
-                expected_grades[student_id] = expected_grades.get(student_id, {})
-                expected_grades[student_id][key_concept] = random_grade_generator()
+                actual_grades[student_id] = actual_grades.get(student_id, {})
+                actual_grades[student_id][key_concept] = random_grade_generator()
 
         passing_grades = ['Extensive Evidence', 'Convincing Evidence']
-        report.generate_html_output(output_file, prompt, rubric, None, actual_grades, expected_grades, passing_grades, {}, [], "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, None, predicted_grades, actual_grades, passing_grades, {}, [], "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            predicted_grades=predicted_grades,
+            actual_grades=actual_grades,
+            passing_grades=passing_grades,
+            command_line="./assess.py",
+        )
 
         output = self._get_output(mock_file)
 
-        for student_id, grades in actual_grades.items():
+        for student_id, grades in predicted_grades.items():
             for grade in grades:
                 key_concept = grade['Key Concept']
 
-                assert re.search(fr'<td>{key_concept}</td>.*>{expected_grades[student_id][key_concept]}<', output)
+                assert re.search(fr'<td>{key_concept}</td>.*>{actual_grades[student_id][key_concept]}<', output)
                 assert re.search(fr'<td>{key_concept}</td>.*>{grade["Grade"]}<', output)
 
     def test_should_report_errors(self, mocker, report, prompt, rubric, random_grade_generator, randomstring):
@@ -263,7 +324,14 @@ class TestGenerateHtmlOutput:
         for _ in range(0, random.randint(1, 5)):
             errors.append(randomstring(12))
 
-        report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, errors, "./assess.py", {}, [], [])
+        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, errors, "./assess.py", {}, [], [])
+        report.generate_html_output(
+            output_file,
+            prompt,
+            rubric,
+            errors=errors,
+            command_line="./assess.py",
+        )
 
         output = self._get_output(mock_file)
 

--- a/tests/unit/assessment/test_report.py
+++ b/tests/unit/assessment/test_report.py
@@ -285,7 +285,6 @@ class TestGenerateHtmlOutput:
                 actual_labels[student_id][key_concept] = random_label_generator()
 
         passing_labels = ['Extensive Evidence', 'Convincing Evidence']
-        # report.generate_html_output(output_file, prompt, rubric, None, predicted_labels, actual_labels, passing_labels, {}, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,

--- a/tests/unit/assessment/test_report.py
+++ b/tests/unit/assessment/test_report.py
@@ -15,25 +15,25 @@ def report():
 
 
 class TestAccurate:
-    def test_should_just_match_actual_to_predicted_if_no_passing_grades(self):
+    def test_should_just_match_actual_to_predicted_if_no_passing_labels(self):
         assert Report.accurate('No Evidence', 'No Evidence', None)
 
-    def test_should_return_false_when_actual_is_not_predicted_if_no_passing_grades(self):
+    def test_should_return_false_when_actual_is_not_predicted_if_no_passing_labels(self):
         assert Report.accurate('No Evidence', 'Limited Evidence', None) == False
 
-    def test_should_count_equal_number_of_matching_grades_in_given_passing_grades(self):
+    def test_should_count_equal_number_of_matching_labels_in_given_passing_labels(self):
         assert Report.accurate('Convincing Evidence', 'Convincing Evidence', ['Convincing Evidence', 'Extensive Evidence'])
 
-    def test_should_be_true_when_actual_not_matching_predicted_but_both_in_given_passing_grades(self):
+    def test_should_be_true_when_actual_not_matching_predicted_but_both_in_given_passing_labels(self):
         assert Report.accurate('Convincing Evidence', 'Extensive Evidence', ['Convincing Evidence', 'Extensive Evidence'])
 
-    def test_should_return_true_when_neither_are_in_set_of_passing_grades(self):
+    def test_should_return_true_when_neither_are_in_set_of_passing_labels(self):
         assert Report.accurate('No Evidence', 'Limited Evidence', ['Convincing Evidence', 'Extensive Evidence'])
 
-    def test_should_return_false_when_actual_is_not_in_set_of_passing_grades(self):
+    def test_should_return_false_when_actual_is_not_in_set_of_passing_labels(self):
         assert Report.accurate('No Evidence', 'Convincing Evidence', ['Convincing Evidence', 'Extensive Evidence']) == False
 
-    def test_should_return_false_when_predicted_is_not_in_set_of_passing_grades(self):
+    def test_should_return_false_when_predicted_is_not_in_set_of_passing_labels(self):
         assert Report.accurate('Convincing Evidence', 'No Evidence', ['Convincing Evidence', 'Extensive Evidence']) == False
 
 
@@ -61,7 +61,6 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        # report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,
@@ -80,7 +79,6 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        # report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,
@@ -103,7 +101,6 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        # report.generate_html_output(output_file, prompt, rubric, "42", {}, {}, [], {}, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,
@@ -127,7 +124,6 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,
@@ -163,7 +159,6 @@ class TestGenerateHtmlOutput:
             else:
                 accuracy_by_criteria[key_concept] = random.randint(0, 100)
 
-        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], accuracy_by_criteria, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,
@@ -185,19 +180,18 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        grades = ['a', 'b', 'c', 'd']
+        labels = ['a', 'b', 'c', 'd']
         confusion_by_criteria = {}
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
         key_concepts = [x['Key Concept'] for x in parsed_rubric]
         overall_confusion = []
-        for g in grades:
-            overall_confusion.append(random.sample(range(0, 100), len(grades)))
+        for l in labels:
+            overall_confusion.append(random.sample(range(0, 100), len(labels)))
         for key_concept in key_concepts:
             confusion_by_criteria[key_concept] = []
-            for g in grades:
-                confusion_by_criteria[key_concept].append(random.sample(range(0, 100), len(grades)))
+            for l in labels:
+                confusion_by_criteria[key_concept].append(random.sample(range(0, 100), len(labels)))
 
-        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, [], "./assess.py", confusion_by_criteria, [], grades)
         report.generate_html_output(
             output_file,
             prompt,
@@ -205,7 +199,7 @@ class TestGenerateHtmlOutput:
             command_line="./assess.py",
             overall_confusion=overall_confusion,
             confusion_by_criteria=confusion_by_criteria,
-            grade_names=grades,
+            label_names=labels,
         )
 
         output = self._get_output(mock_file)
@@ -214,7 +208,7 @@ class TestGenerateHtmlOutput:
         for key_concept in key_concepts:
             assert re.search(fr'<h3>Confusion for {key_concept}:</h3>.*style="text-align: center">{confusion_by_criteria[key_concept][0][0]}<', output)
 
-    def test_should_report_generated_grade_report(self, mocker, report, prompt, rubric, random_grade_generator, randomstring):
+    def test_should_report_generated_label_report(self, mocker, report, prompt, rubric, random_label_generator, randomstring):
         # Generate a random output filename
         output_file = f'{randomstring(10)}.html'
 
@@ -222,47 +216,46 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        predicted_grades = {}
-        actual_grades = {}
+        predicted_labels = {}
+        actual_labels = {}
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
         key_concepts = [x['Key Concept'] for x in parsed_rubric]
         for _ in range(1, random.randint(3, 10)):
             student_id = str(random.randint(100000, 999999))
 
-            predicted_grades[student_id] = list(map(lambda key_concept:
+            predicted_labels[student_id] = list(map(lambda key_concept:
                 {
                     'Key Concept': key_concept,
                     'Observations': 'What I see',
-                    'Grade': random_grade_generator(),
+                    'Grade': random_label_generator(),
                     'Reason': 'Why I think so'
                 },
                 key_concepts
             ))
 
             for key_concept in key_concepts:
-                actual_grades[student_id] = actual_grades.get(student_id, {})
-                actual_grades[student_id][key_concept] = random_grade_generator()
+                actual_labels[student_id] = actual_labels.get(student_id, {})
+                actual_labels[student_id][key_concept] = random_label_generator()
 
-        # report.generate_html_output(output_file, prompt, rubric, None, predicted_grades, actual_grades, [], {}, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,
             rubric,
-            predicted_grades=predicted_grades,
-            actual_grades=actual_grades,
+            predicted_labels=predicted_labels,
+            actual_labels=actual_labels,
             command_line="./assess.py",
         )
 
         output = self._get_output(mock_file)
 
-        for student_id, grades in predicted_grades.items():
-            for grade in grades:
-                key_concept = grade['Key Concept']
+        for student_id, labels in predicted_labels.items():
+            for label in labels:
+                key_concept = label['Key Concept']
 
-                assert re.search(fr'<td>{key_concept}</td>.*>{actual_grades[student_id][key_concept]}<', output)
-                assert re.search(fr'<td>{key_concept}</td>.*>{grade["Grade"]}<', output)
+                assert re.search(fr'<td>{key_concept}</td>.*>{actual_labels[student_id][key_concept]}<', output)
+                assert re.search(fr'<td>{key_concept}</td>.*>{label["Grade"]}<', output)
 
-    def test_should_report_generated_grade_report_with_pass_fail(self, mocker, report, prompt, rubric, random_grade_generator, randomstring):
+    def test_should_report_generated_label_report_with_pass_fail(self, mocker, report, prompt, rubric, random_label_generator, randomstring):
         # Generate a random output filename
         output_file = f'{randomstring(10)}.html'
 
@@ -270,49 +263,49 @@ class TestGenerateHtmlOutput:
         mock_open = mocker.mock_open()
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        predicted_grades = {}
-        actual_grades = {}
+        predicted_labels = {}
+        actual_labels = {}
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
         key_concepts = [x['Key Concept'] for x in parsed_rubric]
         for _ in range(1, random.randint(3, 10)):
             student_id = str(random.randint(100000, 999999))
 
-            predicted_grades[student_id] = list(map(lambda key_concept:
+            predicted_labels[student_id] = list(map(lambda key_concept:
                 {
                     'Key Concept': key_concept,
                     'Observations': 'What I see',
-                    'Grade': random_grade_generator(),
+                    'Grade': random_label_generator(),
                     'Reason': 'Why I think so'
                 },
                 key_concepts
             ))
 
             for key_concept in key_concepts:
-                actual_grades[student_id] = actual_grades.get(student_id, {})
-                actual_grades[student_id][key_concept] = random_grade_generator()
+                actual_labels[student_id] = actual_labels.get(student_id, {})
+                actual_labels[student_id][key_concept] = random_label_generator()
 
-        passing_grades = ['Extensive Evidence', 'Convincing Evidence']
-        # report.generate_html_output(output_file, prompt, rubric, None, predicted_grades, actual_grades, passing_grades, {}, [], "./assess.py", {}, [], [])
+        passing_labels = ['Extensive Evidence', 'Convincing Evidence']
+        # report.generate_html_output(output_file, prompt, rubric, None, predicted_labels, actual_labels, passing_labels, {}, [], "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,
             rubric,
-            predicted_grades=predicted_grades,
-            actual_grades=actual_grades,
-            passing_grades=passing_grades,
+            predicted_labels=predicted_labels,
+            actual_labels=actual_labels,
+            passing_labels=passing_labels,
             command_line="./assess.py",
         )
 
         output = self._get_output(mock_file)
 
-        for student_id, grades in predicted_grades.items():
-            for grade in grades:
-                key_concept = grade['Key Concept']
+        for student_id, labels in predicted_labels.items():
+            for label in labels:
+                key_concept = label['Key Concept']
 
-                assert re.search(fr'<td>{key_concept}</td>.*>{actual_grades[student_id][key_concept]}<', output)
-                assert re.search(fr'<td>{key_concept}</td>.*>{grade["Grade"]}<', output)
+                assert re.search(fr'<td>{key_concept}</td>.*>{actual_labels[student_id][key_concept]}<', output)
+                assert re.search(fr'<td>{key_concept}</td>.*>{label["Grade"]}<', output)
 
-    def test_should_report_errors(self, mocker, report, prompt, rubric, random_grade_generator, randomstring):
+    def test_should_report_errors(self, mocker, report, prompt, rubric, random_label_generator, randomstring):
         # Generate a random output filename
         output_file = f'{randomstring(10)}.html'
 
@@ -324,7 +317,6 @@ class TestGenerateHtmlOutput:
         for _ in range(0, random.randint(1, 5)):
             errors.append(randomstring(12))
 
-        # report.generate_html_output(output_file, prompt, rubric, None, {}, {}, [], {}, errors, "./assess.py", {}, [], [])
         report.generate_html_output(
             output_file,
             prompt,

--- a/tests/unit/assessment/test_rubric_tester.py
+++ b/tests/unit/assessment/test_rubric_tester.py
@@ -10,7 +10,7 @@ from lib.assessment.rubric_tester import (
     get_passing_grades,
     read_inputs,
     get_student_files,
-    get_expected_grades,
+    get_actual_grades,
     validate_rubrics,
     validate_students,
     compute_accuracy,
@@ -122,33 +122,33 @@ class TestGetStudentFiles:
         assert len(result) == 20
 
 
-class TestGetExpectedGrades:
+class TestGetActualGrades:
     def test_should_open_and_parse_the_given_file(self, mocker, rubric, random_grade_generator):
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
         # Build header of key concepts starting with student id
-        expected_csv_data = "student,"
+        actual_csv_data = "student,"
         for key_concept in key_concepts:
-            expected_csv_data += f'{key_concept},'
+            actual_csv_data += f'{key_concept},'
 
         # Chop off leading comma
-        expected_csv_data = expected_csv_data[0:-1]
+        actual_csv_data = actual_csv_data[0:-1]
 
         # Now add random grades
         student_ids = [random.randint(100000, 999999) for _ in range(3, 50)]
         for student_id in student_ids:
-            expected_csv_data += f'\n{student_id},'
+            actual_csv_data += f'\n{student_id},'
             for key_concept in key_concepts:
-                expected_csv_data += f'{random_grade_generator()},'
+                actual_csv_data += f'{random_grade_generator()},'
 
             # Chop off leading comma
-            expected_csv_data = expected_csv_data[0:-1]
+            actual_csv_data = actual_csv_data[0:-1]
 
         # Mock the file read
-        mock_open = mocker.mock_open(read_data=expected_csv_data)
+        mock_open = mocker.mock_open(read_data=actual_csv_data)
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        result = get_expected_grades('expected.csv', "")
+        result = get_actual_grades('actual.csv', "")
 
         # The result it the size of the unique number of student ids
         assert len(result.keys()) == len(list(set(student_ids)))
@@ -186,93 +186,93 @@ class TestGetExamples:
 
 
 class TestValidateRubrics:
-    def test_should_raise_when_expected_grades_contains_a_concept_unknown_to_the_rubric(self, rubric, random_grade_generator, randomstring):
+    def test_should_raise_when_actual_grades_contains_a_concept_unknown_to_the_rubric(self, rubric, random_grade_generator, randomstring):
         student_ids = [random.randint(100000, 999999) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        expected_grades = {}
+        actual_grades = {}
 
         unexpected_concept = randomstring(12)
 
         for student_id in student_ids:
-            expected_grades[student_id] = {
+            actual_grades[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                expected_grades[student_id][key_concept] = random_grade_generator()
-            expected_grades[student_id][unexpected_concept] = random_grade_generator()
+                actual_grades[student_id][key_concept] = random_grade_generator()
+            actual_grades[student_id][unexpected_concept] = random_grade_generator()
 
         with pytest.raises(Exception):
-            validate_rubrics(expected_grades, rubric)
+            validate_rubrics(actual_grades, rubric)
 
 
 class TestValidateStudents:
-    def test_should_raise_when_student_work_exists_without_being_in_expected_grades(self, rubric, random_grade_generator):
+    def test_should_raise_when_student_work_exists_without_being_in_actual_grades(self, rubric, random_grade_generator):
         student_ids = [str(random.randint(100000, 999999)) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        expected_grades = {}
+        actual_grades = {}
         unexpected_student = '199999x'
 
         for student_id in student_ids:
-            expected_grades[student_id] = {
+            actual_grades[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                expected_grades[student_id][key_concept] = random_grade_generator()
+                actual_grades[student_id][key_concept] = random_grade_generator()
 
         student_files = [f'sample_code/{id}.js' for id in student_ids]
         student_files.append(f'sample_code/{unexpected_student}.js')
 
         with pytest.raises(Exception):
-            validate_students(student_files, expected_grades)
+            validate_students(student_files, actual_grades)
 
-    def test_should_not_raise_when_student_work_entirely_exists_in_expected_grades(self, rubric, random_grade_generator):
+    def test_should_not_raise_when_student_work_entirely_exists_in_actual_grades(self, rubric, random_grade_generator):
         student_ids = [str(random.randint(100000, 999999)) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        expected_grades = {}
+        actual_grades = {}
         unexpected_student = '199999x'
 
         for student_id in student_ids:
-            expected_grades[student_id] = {
+            actual_grades[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                expected_grades[student_id][key_concept] = random_grade_generator()
+                actual_grades[student_id][key_concept] = random_grade_generator()
 
         student_files = [f'sample_code/{id}.js' for id in student_ids]
 
-        validate_students(student_files, expected_grades)
+        validate_students(student_files, actual_grades)
 
-    def test_should_not_raise_when_there_is_an_unknown_student_in_expected_grades(self, rubric, random_grade_generator):
+    def test_should_not_raise_when_there_is_an_unknown_student_in_actual_grades(self, rubric, random_grade_generator):
         student_ids = [str(random.randint(100000, 999999)) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        expected_grades = {}
+        actual_grades = {}
         unexpected_student = '199999x'
 
         for student_id in student_ids:
-            expected_grades[student_id] = {
+            actual_grades[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                expected_grades[student_id][key_concept] = random_grade_generator()
+                actual_grades[student_id][key_concept] = random_grade_generator()
 
-        expected_grades[unexpected_student] = {
+        actual_grades[unexpected_student] = {
             'student': unexpected_student
         }
 
         for key_concept in key_concepts:
-            expected_grades[unexpected_student][key_concept] = random_grade_generator()
+            actual_grades[unexpected_student][key_concept] = random_grade_generator()
 
         student_files = [f'sample_code/{id}.js' for id in student_ids]
 
-        validate_students(student_files, expected_grades)
+        validate_students(student_files, actual_grades)
 
 
 class TestComputeAccuracy:

--- a/tests/unit/assessment/test_rubric_tester.py
+++ b/tests/unit/assessment/test_rubric_tester.py
@@ -6,11 +6,11 @@ from unittest import mock
 from types import SimpleNamespace
 
 from lib.assessment.rubric_tester import (
-    grade_student_work,
-    get_passing_grades,
+    label_student_work,
+    get_passing_labels,
     read_inputs,
     get_student_files,
-    get_actual_grades,
+    get_actual_labels,
     validate_rubrics,
     validate_students,
     compute_accuracy,
@@ -22,7 +22,7 @@ from lib.assessment.rubric_tester import (
 from lib.assessment.grade import Grade, InvalidResponseError
 
 
-class TestGradeStudentWork:
+class TestLabelStudentWork:
     def test_should_pass_arguments_through(self, mocker, code, prompt, rubric, examples, student_id, temperature, llm_model):
         grade_student_work_mock = mocker.patch.object(Grade, 'grade_student_work')
 
@@ -38,10 +38,10 @@ class TestGradeStudentWork:
             llm_model=llm_model
         )
 
-        grades = ['good data']
-        grade_student_work_mock.return_value = grades
+        labels = ['good data']
+        grade_student_work_mock.return_value = labels
 
-        result = grade_student_work(
+        result = label_student_work(
             prompt=prompt,
             rubric=rubric,
             student_file=f"blah/{student_id}.js",
@@ -51,20 +51,20 @@ class TestGradeStudentWork:
         )
 
         assert result[0] == student_id
-        assert result[1] == grades
+        assert result[1] == labels
 
 
-class TestGetPassingGrades:
+class TestGetPassingLabels:
     def test_should_return_all_values_when_input_would_indicate_all_values(self):
-        assert len(get_passing_grades(4)) == 4
-        assert get_passing_grades(4).sort() == ['Extensive Evidence', 'Convincing Evidence', 'Limited Evidence', 'No Evidence'].sort()
+        assert len(get_passing_labels(4)) == 4
+        assert get_passing_labels(4).sort() == ['Extensive Evidence', 'Convincing Evidence', 'Limited Evidence', 'No Evidence'].sort()
 
     def test_should_simply_return_top_values(self):
-        assert len(get_passing_grades(2)) == 2
-        assert get_passing_grades(2).sort() == ['Extensive Evidence', 'Convincing Evidence'].sort()
+        assert len(get_passing_labels(2)) == 2
+        assert get_passing_labels(2).sort() == ['Extensive Evidence', 'Convincing Evidence'].sort()
 
-    def test_should_return_none_if_the_number_of_passing_grades_is_none(self):
-        assert get_passing_grades(0) is None
+    def test_should_return_none_if_the_number_of_passing_labels_is_none(self):
+        assert get_passing_labels(0) is None
 
 
 class TestReadInputs:
@@ -122,8 +122,8 @@ class TestGetStudentFiles:
         assert len(result) == 20
 
 
-class TestGetActualGrades:
-    def test_should_open_and_parse_the_given_file(self, mocker, rubric, random_grade_generator):
+class TestGetActualLabels:
+    def test_should_open_and_parse_the_given_file(self, mocker, rubric, random_label_generator):
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
         # Build header of key concepts starting with student id
@@ -134,12 +134,12 @@ class TestGetActualGrades:
         # Chop off leading comma
         actual_csv_data = actual_csv_data[0:-1]
 
-        # Now add random grades
+        # Now add random labels
         student_ids = [random.randint(100000, 999999) for _ in range(3, 50)]
         for student_id in student_ids:
             actual_csv_data += f'\n{student_id},'
             for key_concept in key_concepts:
-                actual_csv_data += f'{random_grade_generator()},'
+                actual_csv_data += f'{random_label_generator()},'
 
             # Chop off leading comma
             actual_csv_data = actual_csv_data[0:-1]
@@ -148,7 +148,7 @@ class TestGetActualGrades:
         mock_open = mocker.mock_open(read_data=actual_csv_data)
         mock_file = mocker.patch('builtins.open', mock_open)
 
-        result = get_actual_grades('actual.csv', "")
+        result = get_actual_labels('actual.csv', "")
 
         # The result it the size of the unique number of student ids
         assert len(result.keys()) == len(list(set(student_ids)))
@@ -186,93 +186,93 @@ class TestGetExamples:
 
 
 class TestValidateRubrics:
-    def test_should_raise_when_actual_grades_contains_a_concept_unknown_to_the_rubric(self, rubric, random_grade_generator, randomstring):
+    def test_should_raise_when_actual_labels_contains_a_concept_unknown_to_the_rubric(self, rubric, random_label_generator, randomstring):
         student_ids = [random.randint(100000, 999999) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        actual_grades = {}
+        actual_labels = {}
 
         unexpected_concept = randomstring(12)
 
         for student_id in student_ids:
-            actual_grades[student_id] = {
+            actual_labels[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                actual_grades[student_id][key_concept] = random_grade_generator()
-            actual_grades[student_id][unexpected_concept] = random_grade_generator()
+                actual_labels[student_id][key_concept] = random_label_generator()
+            actual_labels[student_id][unexpected_concept] = random_label_generator()
 
         with pytest.raises(Exception):
-            validate_rubrics(actual_grades, rubric)
+            validate_rubrics(actual_labels, rubric)
 
 
 class TestValidateStudents:
-    def test_should_raise_when_student_work_exists_without_being_in_actual_grades(self, rubric, random_grade_generator):
+    def test_should_raise_when_student_work_exists_without_being_in_actual_labels(self, rubric, random_label_generator):
         student_ids = [str(random.randint(100000, 999999)) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        actual_grades = {}
+        actual_labels = {}
         unexpected_student = '199999x'
 
         for student_id in student_ids:
-            actual_grades[student_id] = {
+            actual_labels[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                actual_grades[student_id][key_concept] = random_grade_generator()
+                actual_labels[student_id][key_concept] = random_label_generator()
 
         student_files = [f'sample_code/{id}.js' for id in student_ids]
         student_files.append(f'sample_code/{unexpected_student}.js')
 
         with pytest.raises(Exception):
-            validate_students(student_files, actual_grades)
+            validate_students(student_files, actual_labels)
 
-    def test_should_not_raise_when_student_work_entirely_exists_in_actual_grades(self, rubric, random_grade_generator):
+    def test_should_not_raise_when_student_work_entirely_exists_in_actual_labels(self, rubric, random_label_generator):
         student_ids = [str(random.randint(100000, 999999)) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        actual_grades = {}
+        actual_labels = {}
         unexpected_student = '199999x'
 
         for student_id in student_ids:
-            actual_grades[student_id] = {
+            actual_labels[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                actual_grades[student_id][key_concept] = random_grade_generator()
+                actual_labels[student_id][key_concept] = random_label_generator()
 
         student_files = [f'sample_code/{id}.js' for id in student_ids]
 
-        validate_students(student_files, actual_grades)
+        validate_students(student_files, actual_labels)
 
-    def test_should_not_raise_when_there_is_an_unknown_student_in_actual_grades(self, rubric, random_grade_generator):
+    def test_should_not_raise_when_there_is_an_unknown_student_in_actual_labels(self, rubric, random_label_generator):
         student_ids = [str(random.randint(100000, 999999)) for _ in range(3, random.randint(10, 40))]
         key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        actual_grades = {}
+        actual_labels = {}
         unexpected_student = '199999x'
 
         for student_id in student_ids:
-            actual_grades[student_id] = {
+            actual_labels[student_id] = {
                 'student': student_id
             }
 
             for key_concept in key_concepts:
-                actual_grades[student_id][key_concept] = random_grade_generator()
+                actual_labels[student_id][key_concept] = random_label_generator()
 
-        actual_grades[unexpected_student] = {
+        actual_labels[unexpected_student] = {
             'student': unexpected_student
         }
 
         for key_concept in key_concepts:
-            actual_grades[unexpected_student][key_concept] = random_grade_generator()
+            actual_labels[unexpected_student][key_concept] = random_label_generator()
 
         student_files = [f'sample_code/{id}.js' for id in student_ids]
 
-        validate_students(student_files, actual_grades)
+        validate_students(student_files, actual_labels)
 
 
 class TestComputeAccuracy:


### PR DESCRIPTION
Jira Ticket here: https://codedotorg.atlassian.net/browse/AITT-405

This renames the following variables:
"actual" -> "predicted"
"expected" -> "actual"
"grade" -> "label"

There are several instances of "grade" that are reference in the API and not relabelled to avoid breaking anything-
filename `grade.py`
The class `Grade`
The main method of that class `grade_student_work()`
The main method `grade()` of `assess.py`
The key `Grade` that is generated by OpenAI following a prompt
