### PR TITLE
propagate tags from the ECS service to its tasks

### DIFF
--- a/cicd/3-app/aiproxy/template.yml
+++ b/cicd/3-app/aiproxy/template.yml
@@ -142,6 +142,7 @@ Resources:
       DesiredCount: 1
       LaunchType: FARGATE
       TaskDefinition: !Ref ECSTaskDefinition
+      PropagateTags: SERVICE
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED


### PR DESCRIPTION
When we create the cloudformation stack, we can specify tags that are applied to all resources within the template. Currently we specify the `EnvType` tag, which might be `test` or `production`, etc.

However, when an ECS Service spawns ECS Tasks, those tasks do not inherit tags automatically.

This PR uses the `PropagateTags` setting to specify that tasks should inherit tags from the ECS Service. The other option is to inherit from the Task Definition. Today, either of those would have the same effect, but inheriting from the service makes more sense to me.

Use Case: I would like to query all running tasks and their creation dates to see what tasks might be impacted by an impending automatic update in ECS. All tasks created before a certain date are going to be automatically recycled. By adding the Service tags to the tasks, I can more easily filter by environment to understand what resources are impacted.

This is a setting we should consider adding for any other ECS services we create.