### PR TITLE
Refactor templates to have fewer imported values

### DIFF
--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -27,7 +27,6 @@ Resources:
                 - codepipeline.amazonaws.com
         Version: '2012-10-17'
       Path: /service-role/
-      PermissionsBoundary: !ImportValue IAM-DevPermissions
       Policies:
         - PolicyName: AiProxyPassRole
           PolicyDocument:
@@ -103,7 +102,6 @@ Resources:
                 - codebuild.amazonaws.com
         Version: '2012-10-17'
       Path: /service-role/
-      PermissionsBoundary: !ImportValue IAM-DevPermissions
       Policies:
         - PolicyName: PublicCodeBuildSecretsAccess
           PolicyDocument:

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -42,7 +42,7 @@ Resources:
                   - "cloudformation:DescribeStacks"
                   - "cloudformation:CreateStack"
                   - "cloudformation:UpdateStack"
-                Resource: "*"
+                Resource: "*" # TODO scope to specific stacks
         - PolicyName: CodeBuildResourcesAccess
           PolicyDocument:
             Statement:
@@ -67,11 +67,10 @@ Resources:
                   - s3:GetObjectVersion
                 Resource:
                   - !Sub ${ArtifactStore.Arn}/*
-              # TODO: Scope to specific ECR Repos?
               - Effect: Allow
                 Action:
                   - ecr:GetAuthorizationToken
-                Resource: '*'
+                Resource: '*' # TODO scope to specific ECR repos
               - Effect: Allow
                 Action: codestar-connections:UseConnection
                 Resource:

--- a/cicd/1-setup/deploy-cicd-dependencies.sh
+++ b/cicd/1-setup/deploy-cicd-dependencies.sh
@@ -11,23 +11,38 @@ TEMPLATE_FILE=cicd/1-setup/cicd-dependencies.template.yml
 echo Validating cloudformation template...
 aws cloudformation validate-template \
   --template-body file://${TEMPLATE_FILE} \
-  | cat
+  > /dev/null
 
 ACCOUNT=$(aws sts get-caller-identity --query "Account" --output text)
+REGION=$(aws configure get region)
 
-read -r -p "Would you like to deploy this template to AWS account $ACCOUNT? [y/N] " response
+read -r -p "Would you like to create a change set for this template in AWS account $ACCOUNT? [y/N] " response
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
 then
-  echo Updating cloudformation stack...
-  echo "Follow along at https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks?filteringText=aiproxy-cicd-deps&filteringStatus=active&viewNested=true&hideStacks=false"
-  aws cloudformation deploy \
+  echo Creating change set...
+  CHANGE_SET_NAME="aiproxy-cicd-deps-changeset-$(date +%s)"
+  aws cloudformation create-change-set \
     --stack-name aiproxy-cicd-deps \
-    --template-file ${TEMPLATE_FILE} \
+    --change-set-name $CHANGE_SET_NAME \
+    --template-body file://${TEMPLATE_FILE} \
     --capabilities CAPABILITY_IAM \
     --tags EnvType=infrastructure \
     "$@"
 
-  echo Complete!
+  echo "Change set created. You can review it at:"
+  echo "https://console.aws.amazon.com/cloudformation/home?region=$REGION#/stacks/changesets/changes?stackId=arn:aws:cloudformation:$REGION:$ACCOUNT:stack/aiproxy-cicd-deps/*&changeSetId=arn:aws:cloudformation:$REGION:$ACCOUNT:changeSet/$CHANGE_SET_NAME"
+
+  read -r -p "Would you like to execute the change set? [y/N] " response
+  if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+  then
+    echo Executing change set...
+    aws cloudformation execute-change-set \
+      --stack-name aiproxy-cicd-deps \
+      --change-set-name $CHANGE_SET_NAME
+    echo Complete!
+  else
+    echo Exiting...
+  fi
 else
   echo Exiting...
 fi

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -40,8 +40,11 @@ Conditions:
 
 Resources:
 
-  # The Elastic Container Registry Repository will store our built docker
-  # images.
+  #-------------------------------------
+  # Elastic Container Registry (ECR)
+  # - Store built docker images
+  #-------------------------------------
+
   EcrRepository:
     Type: AWS::ECR::Repository
     Properties: 
@@ -112,6 +115,10 @@ Resources:
               - 'kms:GenerateDataKey'
               - 'kms:GenerateDataKeyWithoutPlaintext'
             Resource: '*'
+
+  #-------------------------------------
+  # CodeBuild Projects
+  #-------------------------------------
 
   # The CodeBuild Project is triggered by pull requests targeting $GitHubBranch
   # It will perform any steps defined in the pr-buildspec.yml file.
@@ -191,32 +198,9 @@ Resources:
       Artifacts:
         Type: CODEPIPELINE
 
-  # Grant the AiProxy CodeBuild Role additional permissions for resources in
-  # this template. This allows us to avoid granting permission to * resources.
-  AiProxyRolePolicy:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyName: !Sub "${AWS::StackName}-codebuild-policy"
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - codebuild:*
-            Resource:
-              - !GetAtt AppBuildProject.Arn
-              - !GetAtt IntegrationTestBuildProject.Arn
-          - Effect: Allow
-            Action:
-              - codebuild:CreateReportGroup
-              - codebuild:CreateReport
-              - codebuild:UpdateReport
-              - codebuild:BatchPutTestCases
-              - codebuild:BatchPutCodeCoverage
-            Resource:
-              - !Sub arn:aws:codebuild:us-east-1:165336972514:report-group/${AWS::StackName}-${GitHubBranch}-pr-build
-      Roles:
-        - !ImportValue AiProxyCodeBuildRoleName
+  #-------------------------------------
+  # Pipeline
+  #-------------------------------------
 
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -430,6 +414,42 @@ Resources:
                   - Name: smokeTestResults
           - !Ref AWS::NoValue
   
+
+  #-------------------------------------
+  # IAM Roles & Policies
+  #-------------------------------------
+
+  # Grant the AiProxy CodeBuild Role additional permissions for resources in
+  # this template. This allows us to avoid granting permission to * resources.
+  AiProxyRolePolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: !Sub "${AWS::StackName}-codebuild-policy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - codebuild:*
+            Resource:
+              - !GetAtt AppBuildProject.Arn
+              - !GetAtt IntegrationTestBuildProject.Arn
+          - Effect: Allow
+            Action:
+              - codebuild:CreateReportGroup
+              - codebuild:CreateReport
+              - codebuild:UpdateReport
+              - codebuild:BatchPutTestCases
+              - codebuild:BatchPutCodeCoverage
+            Resource:
+              - !Sub arn:aws:codebuild:us-east-1:165336972514:report-group/${AWS::StackName}-${GitHubBranch}-pr-build
+      Roles:
+        - !ImportValue AiProxyCodeBuildRoleName
+
+  #-------------------------------------
+  # Metrics & Notifications
+  #-------------------------------------
+
   # Send pipeline events to an SNS topic.
   # Note:
   # Integration with Slack via AWS ChatBot is configured manually via AWS

--- a/cicd/2-cicd/cicd.template.yml
+++ b/cicd/2-cicd/cicd.template.yml
@@ -278,11 +278,25 @@ Resources:
                   ActionMode: CREATE_UPDATE
                   TemplatePath: appBuildResults::packaged-app-template.yml
                   TemplateConfiguration: appBuildResults::cicd/3-app/aiproxy/dev.config.json
+                  # ParameterOverrides must be a JSON string, not an object
                   ParameterOverrides: !Join
-                      - ''
-                      - - '{ "SubdomainName": "'
-                        - !Sub "aiproxy-dev-${GitHubBranch}"
-                        - '" }'
+                    - ''
+                    - - '{'
+                      - !Sub '"SubdomainName": "aiproxy-dev-${GitHubBranch}",'
+                      - !Sub '"ECRRepositoryArn": "${EcrRepository.Arn}",'
+                      - !Sub
+                        - '"VPC": "${VPCValue}",'
+                        - { VPCValue: !ImportValue VPC }
+                      - !Sub
+                        - '"SecurityGroup": "${SecurityGroupValue}",'
+                        - { SecurityGroupValue: !ImportValue VPC-ELBSecurityGroup }
+                      - !Sub
+                        - '"PublicSubnets": ${PublicSubnetsValue},'
+                        - { PublicSubnetsValue: [!ImportValue VPC-PublicSubnetB, !ImportValue VPC-PublicSubnetC, !ImportValue VPC-PublicSubnetD, !ImportValue VPC-PublicSubnetE] }
+                      - !Sub
+                        - '"PrivateSubnets": ${PrivateSubnetsValue},'
+                        - { PrivateSubnetsValue: [!ImportValue VPC-SubnetB, !ImportValue VPC-SubnetC, !ImportValue VPC-SubnetD, !ImportValue VPC-SubnetE] }
+                      - '}'
                   Capabilities: CAPABILITY_AUTO_EXPAND,CAPABILITY_IAM
                   RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService
           - !Ref AWS::NoValue
@@ -304,11 +318,27 @@ Resources:
                   ActionMode: CREATE_UPDATE
                   TemplatePath: appBuildResults::packaged-app-template.yml
                   TemplateConfiguration: appBuildResults::cicd/3-app/aiproxy/test.config.json
+                  # ParameterOverrides must be a JSON string, not an object
                   ParameterOverrides: !Join
                     - ''
-                    - - '{ "SubdomainName": "'
-                      - !If [ TargetsMainBranch, 'aiproxy-test', !Sub 'aiproxy-test-${GitHubBranch}' ]
-                      - '" }'
+                    - - '{'
+                      - !Sub
+                        - '"SubdomainName": "${SubdomainName}",'
+                        - { SubdomainName: !If [ TargetsMainBranch, 'aiproxy-test', !Sub 'aiproxy-test-${GitHubBranch}' ] }
+                      - !Sub '"ECRRepositoryArn": "${EcrRepository.Arn}",'
+                      - !Sub
+                        - '"VPC": "${VPCValue}",'
+                        - { VPCValue: !ImportValue VPC }
+                      - !Sub
+                        - '"SecurityGroup": "${SecurityGroupValue}",'
+                        - { SecurityGroupValue: !ImportValue VPC-ELBSecurityGroup }
+                      - !Sub
+                        - '"PublicSubnets": ${PublicSubnetsValue},'
+                        - { PublicSubnetsValue: [!ImportValue VPC-PublicSubnetB, !ImportValue VPC-PublicSubnetC, !ImportValue VPC-PublicSubnetD, !ImportValue VPC-PublicSubnetE] }
+                      - !Sub
+                        - '"PrivateSubnets": ${PrivateSubnetsValue},'
+                        - { PrivateSubnetsValue: [!ImportValue VPC-SubnetB, !ImportValue VPC-SubnetC, !ImportValue VPC-SubnetD, !ImportValue VPC-SubnetE] }
+                      - '}'
                   Capabilities: CAPABILITY_AUTO_EXPAND,CAPABILITY_IAM
                   RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService
           - !Ref AWS::NoValue
@@ -353,11 +383,27 @@ Resources:
                   ActionMode: CREATE_UPDATE
                   TemplatePath: appBuildResults::packaged-app-template.yml
                   TemplateConfiguration: appBuildResults::cicd/3-app/aiproxy/production.config.json
+                  # ParameterOverrides must be a JSON string, not an object
                   ParameterOverrides: !Join
                     - ''
-                    - - '{ "SubdomainName": "'
-                      - !If [ TargetsMainBranch, 'aiproxy', !Sub 'aiproxy-${GitHubBranch}' ]
-                      - '" }'
+                    - - '{'
+                      - !Sub
+                        - '"SubdomainName": "${SubdomainName}",'
+                        - { SubdomainName: !If [ TargetsMainBranch, 'aiproxy', !Sub 'aiproxy-${GitHubBranch}' ] }
+                      - !Sub '"ECRRepositoryArn": "${EcrRepository.Arn}",'
+                      - !Sub
+                        - '"VPC": "${VPCValue}",'
+                        - { VPCValue: !ImportValue VPC }
+                      - !Sub
+                        - '"SecurityGroup": "${SecurityGroupValue}",'
+                        - { SecurityGroupValue: !ImportValue VPC-ELBSecurityGroup }
+                      - !Sub
+                        - '"PublicSubnets": ${PublicSubnetsValue},'
+                        - { PublicSubnetsValue: [!ImportValue VPC-PublicSubnetB, !ImportValue VPC-PublicSubnetC, !ImportValue VPC-PublicSubnetD, !ImportValue VPC-PublicSubnetE] }
+                      - !Sub
+                        - '"PrivateSubnets": ${PrivateSubnetsValue},'
+                        - { PrivateSubnetsValue: [!ImportValue VPC-SubnetB, !ImportValue VPC-SubnetC, !ImportValue VPC-SubnetD, !ImportValue VPC-SubnetE] }
+                      - '}'
                   Capabilities: CAPABILITY_AUTO_EXPAND,CAPABILITY_IAM
                   RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService
           - !Ref AWS::NoValue

--- a/cicd/2-cicd/deploy-cicd.sh
+++ b/cicd/2-cicd/deploy-cicd.sh
@@ -8,38 +8,39 @@ echo Deploying AiProxy CICD Pipeline
 # - ENVIRONMENT_TYPE: Can be 'production' (default) or 'development', passed as a Parameter for "cicd/2-cicd/cicd.template.yml"
 # - GITHUB_BADGE_ENABLED: defaults to true, passed as a Parameter for "cicd/2-cicd/cicd.template.yml"
 
+# The branch name may become part of a domain name, so we need to validate it.
+validate_branch_name() {
+  local branch_name=$1
+  if [[ ! $branch_name =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])$ ]]; then
+    echo "Invalid branch name '${branch_name}', branches must be alphanumeric and may contain hyphens."
+    exit 1
+  fi
+}
+
 # 'Developer' role requires a specific service role for all CloudFormation operations.
 if [[ $(aws sts get-caller-identity --query Arn --output text) =~ "assumed-role/Developer/" ]]; then
   # Append the role-arn option to the positional parameters $@ passed to cloudformation deploy.
   set -- "$@" --role-arn "arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/admin/CloudFormationService"
 fi
 
-# Default to main branch, but support pipelines using other branches
-TARGET_BRANCH=${TARGET_BRANCH-'main'}
+ENVIRONMENT_TYPE=${ENVIRONMENT_TYPE:-'production'}
+GITHUB_BADGE_ENABLED=${GITHUB_BADGE_ENABLED:-'true'}
+TARGET_BRANCH=${TARGET_BRANCH:-'main'}
 
 if [ "$TARGET_BRANCH" == "main" ]
 then
   STACK_NAME="aiproxy-cicd"
 else
-  # only allow alphanumeric branch names that may contain an internal hyphen.
-  # to avoid complicated logic elsewhere, we're constraining it here.
-  if [[ "$TARGET_BRANCH" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])$ ]]; then
-    STACK_NAME="aiproxy-${TARGET_BRANCH}-cicd"
-  else
-    echo "Invalid branch name '${TARGET_BRANCH}', branches must be alphanumeric and may contain hyphens."
-    exit
-  fi
+  validate_branch_name "$TARGET_BRANCH"
+  STACK_NAME="aiproxy-${TARGET_BRANCH}-cicd"
 fi
-
-ENVIRONMENT_TYPE=${ENVIRONMENT_TYPE-'production'}
-GITHUB_BADGE_ENABLED=${GITHUB_BADGE_ENABLED-'true'}
 
 TEMPLATE_FILE=cicd/2-cicd/cicd.template.yml
 
 echo Validating cloudformation template...
 aws cloudformation validate-template \
   --template-body file://${TEMPLATE_FILE} \
-  | cat
+  > /dev/null
 
 ACCOUNT=$(aws sts get-caller-identity --query "Account" --output text)
 

--- a/cicd/3-app/aiproxy/template.yml
+++ b/cicd/3-app/aiproxy/template.yml
@@ -2,8 +2,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
 Description: Provision an instance of the AI Proxy service.
 
-# Dependencies: This template has dependencies, look for !ImportValue in the Resources section.
-
 Parameters:
   BaseDomainName:
     Type: String
@@ -14,9 +12,20 @@ Parameters:
   SubdomainName:
     Type: String
     Description: Subdomain name for aiproxy service (e.g. 'aiproxy' in 'aiproxy.code.org').
+  ECRRepositoryArn:
+    Type: String
+    Description: ARN of the ECR repository for this service.
   AppImageUri:
     Type: String
     Description: URI of the Docker image in ECR.
+  VPC:
+    Type: AWS::EC2::VPC::Id
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup::Id
+  PublicSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+  PrivateSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
 
 # Conditions:
 #   IsDevCondition: !Equals [!Ref BaseDomainName, "dev-code.org"]
@@ -63,16 +72,11 @@ Resources:
       LoadBalancerAttributes:
         - Key: idle_timeout.timeout_seconds
           Value: 180
-      SecurityGroups:
-        - !ImportValue VPC-ELBSecurityGroup
-      Subnets:
-        # Place load balancer in public subnets, so it's accessible from the internet.
-        # We may want to move this to the private subnets, so only internal resources
-        # can access it, but this is very convenient for local development.
-        - !ImportValue VPC-PublicSubnetB
-        - !ImportValue VPC-PublicSubnetC
-        - !ImportValue VPC-PublicSubnetD
-        - !ImportValue VPC-PublicSubnetE
+      SecurityGroups: !Ref LoadBalancerSecurityGroups
+      # Place load balancer in public subnets, so it's accessible from the internet.
+      # We may want to move this to the private subnets, so only internal resources
+      # can access it, but this is very convenient for local development.
+      Subnets: !Ref PublicSubnets
 
   HttpListener:
    Type: AWS::ElasticLoadBalancingV2::Listener
@@ -114,7 +118,7 @@ Resources:
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      VpcId: !ImportValue VPC
+      VpcId: !Ref VPC
       Port: 80
       TargetType: ip
       Protocol: HTTP
@@ -147,12 +151,8 @@ Resources:
           AssignPublicIp: DISABLED
           SecurityGroups: 
             - !Ref ECSSecurityGroup
-          Subnets:
             # Place ECS Service in private subnets, but traffic should use the LoadBalancer.
-            - !ImportValue VPC-SubnetB
-            - !ImportValue VPC-SubnetC
-            - !ImportValue VPC-SubnetD
-            - !ImportValue VPC-SubnetE
+          Subnets: !Ref PrivateSubnets
       LoadBalancers:
         - ContainerName: aiproxy
           ContainerPort: 80
@@ -163,7 +163,7 @@ Resources:
     Properties: 
       GroupDescription: Security Group for ECS Service
       # TODO: This copies geocoder, but we should probably have a separate VPC for this service.
-      VpcId: !ImportValue VPC
+      VpcId: !Ref VPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
@@ -177,7 +177,7 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       NetworkMode: awsvpc
-      ExecutionRoleArn: !ImportValue AiProxyECSTaskExecutionRoleArn
+      ExecutionRoleArn: !GetAtt ECSTaskExecutionRole.Arn
       Cpu: 256
       Memory: 512
       ContainerDefinitions:
@@ -195,12 +195,50 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: ecs
 
+  ECSTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: ECRPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecr:GetAuthorizationToken
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchGetImage
+                Resource: !Ref ECRRepositoryArn
+        - PolicyName: LogsPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !GetAtt LogGroup.Arn
+                  - !Sub "${LogGroup.Arn}:*"
+
   # ------------------
   #  Logging & Alerts
   # ------------------
 
   LogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Retain
     Properties:
       LogGroupName: !Sub "${AWS::StackName}"
 


### PR DESCRIPTION
!ImportValue adds cross-stack dependencies and breaks the cleaner top-down passing of parameters. This PR eliminates !ImportValue from the application stack via two changes:

* The CICD pipeline stack tells the app stacks what VPC, security group, and subnets to use
* The app stack creates it's own ECS Task Execution Role

This also modifies the deploy scripts to create a change set which can be reviewed before applying.