### PR TITLE
add llama2 model options

### DIFF
--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -1,6 +1,14 @@
 VALID_LABELS = ["Extensive Evidence", "Convincing Evidence", "Limited Evidence", "No Evidence"]
 # do not include gpt-4, so that we always know what version of the model we are using.
-SUPPORTED_MODELS = ['gpt-4-0314', 'gpt-4-32k-0314', 'gpt-4-0613', 'gpt-4-32k-0613', 'gpt-4-1106-preview']
+SUPPORTED_MODELS = [
+    'meta.llama2-13b-chat-v1',
+    'meta.llama2-70b-chat-v1',
+    'gpt-4-0314',
+    'gpt-4-32k-0314',
+    'gpt-4-0613',
+    'gpt-4-32k-0613',
+    'gpt-4-1106-preview'
+]
 DEFAULT_MODEL = 'gpt-4-0613'
 LESSONS = {
     # "U3-2022-L10" : "1ROCbvHb3yWGVoQqzKAjwdaF0dSRPUjy_",

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -84,7 +84,7 @@ class Label:
         }
 
     def compute_meta_prompt(self, prompt, rubric, student_code, examples=[]):
-            return f"{prompt}\n\nRubric:\n{rubric}\n\nStudent Code:\n{student_code}"
+            return f"{prompt}\n\nRubric:\n{rubric}\n\nStudent Code:\n{student_code}\n\nAssistant:\n"
 
     def openai_label_student_work(self, prompt, rubric, student_code, student_id, examples=[], num_responses=0, temperature=0.0, llm_model=""):
         # Determine the OpenAI URL and headers

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -60,22 +60,21 @@ class Label:
         bedrock = boto3.client(service_name='bedrock-runtime')
 
         meta_prompt = self.compute_meta_prompt(prompt, rubric, student_code, examples=examples)
-        logging.info(f"meta_prompt:\n{meta_prompt}")
         body = json.dumps({
             "prompt": meta_prompt,
             "max_gen_len": 1024,
             "temperature": temperature,
-            # "top_p": 0.9,
         })
         accept = 'application/json'
         content_type = 'application/json'
         response = bedrock.invoke_model(body=body, modelId=llm_model, accept=accept, contentType=content_type)
 
         response_body = json.loads(response.get('body').read())
+        #logging.info(f"raw AI response:\n{response_body}")
         generation = response_body.get('generation')
-        logging.info(f"AI response:\n{generation}")
 
         data = self.get_json_data_if_valid(generation, rubric, student_id)
+        #logging.info(f"AI response json:\n{json.dumps(data, indent=2)}")
 
         return {
             'metadata': {

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -60,6 +60,7 @@ class Label:
         bedrock = boto3.client(service_name='bedrock-runtime')
 
         meta_prompt = self.compute_meta_prompt(prompt, rubric, student_code, examples=examples)
+        logging.info(f"meta_prompt:\n{meta_prompt}")
         body = json.dumps({
             "prompt": meta_prompt,
             "max_gen_len": 1024,
@@ -72,6 +73,7 @@ class Label:
 
         response_body = json.loads(response.get('body').read())
         generation = response_body.get('generation')
+        logging.info(f"AI response:\n{generation}")
 
         tsv_data = self.get_tsv_data_if_valid(generation, rubric, student_id, reraise=True)
 
@@ -84,7 +86,7 @@ class Label:
         }
 
     def compute_meta_prompt(self, prompt, rubric, student_code, examples=[]):
-            return f"{prompt}\n\nRubric:\n{rubric}\n\nStudent Code:\n{student_code}\n\nAssistant:\n"
+            return f"[INST]{prompt}[/INST]\n\nRubric:\n{rubric}\n\nStudent Code:\n{student_code}\n\nEvaluation (JSON):\n"
 
     def openai_label_student_work(self, prompt, rubric, student_code, student_id, examples=[], num_responses=0, temperature=0.0, llm_model=""):
         # Determine the OpenAI URL and headers

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -63,7 +63,7 @@ class Label:
         print(f"meta_prompt:\n", meta_prompt)
         body = json.dumps({
             "prompt": meta_prompt,
-            "max_gen_len": 2048,
+            "max_gen_len": 1024,
             "temperature": temperature,
             # "top_p": 0.9,
         })


### PR DESCRIPTION
### depends on https://github.com/code-dot-org/aiproxy/pull/43

## add llama2 model

this PR adds the ability to select a llama2 model for evaluation. currently, llama2 gives an evaluation of all requested learning goals in JSON format, but accuracy is low (near random).

notable in this PR:
* wrap system prompt text in `[INST]...[/INST]` tags
* change AI response format from TSV to JSON

to try next:
* provide examples