### PR TITLE
Ceara/aitt 406 pull params from s3

### DIFF
--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -2,12 +2,4 @@ VALID_LABELS = ["Extensive Evidence", "Convincing Evidence", "Limited Evidence",
 # do not include gpt-4, so that we always know what version of the model we are using.
 SUPPORTED_MODELS = ['gpt-4-0314', 'gpt-4-32k-0314', 'gpt-4-0613', 'gpt-4-32k-0613', 'gpt-4-1106-preview']
 DEFAULT_MODEL = 'gpt-4-0613'
-LESSONS = {
-    # "U3-2022-L10" : "1ROCbvHb3yWGVoQqzKAjwdaF0dSRPUjy_",
-    # "U3-2022-L13" : "1kGHeY5LRpFJ9xVRoBEWbyOJyKm4wClqw",
-    "U3-2022-L17" : "1WirJLIFgo-anxAz-kZXDVQ2Tl_8OuX22",
-    "U3-2022-L20" : "115BHvZ1kJC2xhUSOBkLiE8DC1YgcjyRd",
-    # "U3-2022-L23" : "12OJex4l9OhWrnbLenpvZAibtfiFWWdzx",
-    "New-U3-2022-L10" : "15xAUFVeGkXeG18mDWBOKN6yJPpI185tg",
-    "New-U3-2022-L13" : "14LI9eRRgxL5rRQK6FoUI0ow_YIb5V0mg",
-}
+LESSONS = ['CSD-2022-U3-L17','New-U3-2022-L10','New-U3-2022-L13','New-U3-2022-L20','New-U3-2023-L24','U3-2023-L28']

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ pytest-mock==3.12.0
 requests-mock==1.11.0
 coverage==7.3.2
 scikit-learn~=1.3.2
-gdown~=4.7.1
 boto3==1.34.30

--- a/tests/unit/assessment/test_rubric_tester.py
+++ b/tests/unit/assessment/test_rubric_tester.py
@@ -47,6 +47,7 @@ class TestLabelStudentWork:
             student_file=f"blah/{student_id}.js",
             examples=examples(rubric),
             options=options,
+            params={},
             prefix=""
         )
 


### PR DESCRIPTION
Replace downloading files from google drive via gdown with pulling files from s3. This also removes gdown as a requirement. It also adds an option `--params` to use options from the `params.json` file in lesson data instead of command line options. 