### PR TITLE
refactor s3 lesson data into datasets and experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ __pycache__
 .venv/
 
 # Ignore rubric testing files
+experiments/
 lesson_data/

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ __pycache__
 .venv/
 
 # Ignore rubric testing files
+datasets/
 experiments/
 lesson_data/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ __pycache__
 # pyenv config
 .python-version
 
+# Mac OS files
+.DS_Store
+
 # Local editor settings
 .vscode
 .idea

--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -3,4 +3,5 @@ VALID_LABELS = ["Extensive Evidence", "Convincing Evidence", "Limited Evidence",
 SUPPORTED_MODELS = ['gpt-4-0314', 'gpt-4-32k-0314', 'gpt-4-0613', 'gpt-4-32k-0613', 'gpt-4-1106-preview']
 DEFAULT_MODEL = 'gpt-4-0613'
 LESSONS = ['csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
+DEFAULT_DATASET_NAME = 'contractor-grades-batch-1-fall-2023'
 DEFAULT_EXPERIMENT_NAME = 'ai-rubrics-pilot-baseline'

--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -2,4 +2,5 @@ VALID_LABELS = ["Extensive Evidence", "Convincing Evidence", "Limited Evidence",
 # do not include gpt-4, so that we always know what version of the model we are using.
 SUPPORTED_MODELS = ['gpt-4-0314', 'gpt-4-32k-0314', 'gpt-4-0613', 'gpt-4-32k-0613', 'gpt-4-1106-preview']
 DEFAULT_MODEL = 'gpt-4-0613'
-LESSONS = ['CSD-2022-U3-L17','New-U3-2022-L10','New-U3-2022-L13','New-U3-2022-L20','New-U3-2023-L24','U3-2023-L28']
+LESSONS = ['csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
+DEFAULT_EXPERIMENT_NAME = 'ai-rubrics-pilot-baseline'

--- a/lib/assessment/report.py
+++ b/lib/assessment/report.py
@@ -82,7 +82,7 @@ class Report:
         confusion_table += '</table>'
         return confusion_table
 
-    def generate_html_output(self, output_file, prompt, rubric, accuracy=None, predicted_labels=None, actual_labels=None, passing_labels=None, accuracy_by_criteria=None, errors=[], command_line=None, confusion_by_criteria=None, overall_confusion=None, label_names=None, prefix='sample_code'):
+    def generate_html_output(self, output_file, prompt, rubric, accuracy=None, predicted_labels=None, actual_labels=None, passing_labels=None, accuracy_by_criteria=None, errors=[], dataset_name=None, command_line=None, confusion_by_criteria=None, overall_confusion=None, label_names=None, prefix='sample_code'):
         link_base_url = f'file://{os.getcwd()}/{prefix}'
 
         with open(output_file, 'w+') as file:
@@ -101,6 +101,10 @@ class Report:
             if len(errors) > 0:
                 file.write(f'  <h2 style="color: red">Errors: {len(errors)}</h2>\n')
                 file.write(f'  <p style="color: red">{", ".join(errors)} failed to load</p>\n')
+
+            if dataset_name:
+                file.write('  <h2>Dataset:</h2>\n')
+                file.write(f'  <pre>{dataset_name}</pre>\n')
 
             if command_line:
                 file.write('  <h2>Command Line:</h2>\n')

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -336,6 +336,7 @@ def main():
             passing_labels=options.passing_labels,
             accuracy_by_criteria=accuracy_by_criteria_percent,
             errors=errors,
+            dataset_name=options.dataset_name,
             command_line=command_line,
             confusion_by_criteria=confusion_by_criteria,
             overall_confusion=overall_confusion,

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -35,7 +35,7 @@ cache_dir_name = 'cached_responses'
 accuracy_threshold_file = 'accuracy_thresholds.json'
 accuracy_threshold_dir = 'tests/data'
 s3_bucket = 'cdo-ai'
-s3_prefix = 'teaching_assistant/experiments'
+s3_root = 'teaching_assistant'
 params_file = 'params.json'
 
 pp = pprint.PrettyPrinter(indent=2)
@@ -160,8 +160,8 @@ def get_examples(prefix):
 def get_s3_folder(s3, experiment_name, lesson_name, prefix):
     print("get_s3_folder args:", experiment_name, lesson_name, prefix)
     bucket = s3.Bucket(s3_bucket)
-    for obj in bucket.objects.filter(Prefix="/".join([s3_prefix, experiment_name, lesson_name])):
-        target = os.path.join(prefix, os.path.relpath(obj.key, "/".join([s3_prefix, experiment_name, lesson_name])))
+    for obj in bucket.objects.filter(Prefix="/".join([s3_root, experiments_dir, experiment_name, lesson_name])):
+        target = os.path.join(prefix, os.path.relpath(obj.key, "/".join([s3_root, experiments_dir, experiment_name, lesson_name])))
         print(f"Copy {obj.key} to {target}")
         if not os.path.exists(os.path.dirname(target)):
             os.makedirs(os.path.dirname(target))

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -269,12 +269,7 @@ def main():
 
         # download lesson files
         if not os.path.exists(experiment_lesson_prefix) or options.download:
-            try:
-                result = subprocess.run('aws sts get-caller-identity', shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                print(f"AWS access configured: {result.stdout}")
-            except subprocess.CalledProcessError as e:
-                print(f"AWS access not configured: {e} {e.stderr}Please see README.md and make sure you ran `gem install aws-google` and `bin/aws_access`")
-                exit(1)
+            check_aws_access()
             try:
                 s3 = boto3.resource("s3")
                 get_s3_folder(s3, experiment_lesson_prefix)
@@ -360,6 +355,13 @@ def main():
 
     return accuracy_pass
 
+def check_aws_access():
+    try:
+        result = subprocess.run('aws sts get-caller-identity', shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        print(f"AWS access configured: {result.stdout}")
+    except subprocess.CalledProcessError as e:
+        print(f"AWS access not configured: {e} {e.stderr}Please see README.md and make sure you ran `gem install aws-google` and `bin/aws_access`")
+        exit(1)
 
 def init():
     if __name__ == '__main__':

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -157,11 +157,10 @@ def get_examples(prefix):
         examples.append((example_code, example_rubric))
     return examples
 
-def get_s3_folder(s3, experiment_name, lesson_name, prefix):
-    print("get_s3_folder args:", experiment_name, lesson_name, prefix)
+def get_s3_experiment_folder(s3, experiment_prefix, experiment_name, lesson_name):
     bucket = s3.Bucket(s3_bucket)
     for obj in bucket.objects.filter(Prefix="/".join([s3_root, experiments_dir, experiment_name, lesson_name])):
-        target = os.path.join(prefix, os.path.relpath(obj.key, "/".join([s3_root, experiments_dir, experiment_name, lesson_name])))
+        target = os.path.join(experiment_prefix, os.path.relpath(obj.key, "/".join([s3_root, experiments_dir, experiment_name, lesson_name])))
         print(f"Copy {obj.key} to {target}")
         if not os.path.exists(os.path.dirname(target)):
             os.makedirs(os.path.dirname(target))
@@ -276,9 +275,9 @@ def main():
                 exit(1)
             try:
                 s3 = boto3.resource("s3")
-                get_s3_folder(s3, options.experiment_name, lesson, experiment_prefix)
+                get_s3_experiment_folder(s3, experiment_prefix, options.experiment_name, lesson)
             except Exception as e:
-                print(f"Could not download lesson {lesson}")
+                print(f"Could not download experiment {options.experiment_name} lesson {lesson}")
                 logging.error(e)
 
         # read in lesson files, validate them

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -30,7 +30,7 @@ standard_rubric_file = 'standard_rubric.csv'
 actual_labels_file_old = 'expected_grades.csv'
 actual_labels_file = 'actual_labels.csv'
 output_dir_name = 'output'
-base_dir = 'experiments'
+experiments_dir = 'experiments'
 cache_dir_name = 'cached_responses'
 accuracy_threshold_file = 'accuracy_thresholds.json'
 accuracy_threshold_dir = 'tests/data'
@@ -263,7 +263,7 @@ def main():
         accuracy_thresholds = get_accuracy_thresholds()
 
     for lesson in options.lesson_names:
-        prefix = os.path.join(base_dir, options.experiment_name, lesson)
+        prefix = os.path.join(experiments_dir, options.experiment_name, lesson)
         data_prefix = os.path.join(prefix, "data")
 
         # download lesson files

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Make sure the caller sees a helpful error message if they try to run this script with Python 2
+f"This script requires {'Python 3'}. Please be sure to activate your virtual environment via `source .venv/bin/activate`."
+
 import argparse
 import csv
 import glob

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -157,10 +157,12 @@ def get_examples(prefix):
         examples.append((example_code, example_rubric))
     return examples
 
-def get_s3_experiment_folder(s3, experiment_lesson_prefix, experiment_name, lesson_name):
+# path_from_s3_root is the path to the source folder relative to s3_root, and is also used as the local destination
+# folder relative to the repo root.
+def get_s3_folder(s3, path_from_s3_root):
     bucket = s3.Bucket(s3_bucket)
-    for obj in bucket.objects.filter(Prefix="/".join([s3_root, experiments_dir, experiment_name, lesson_name])):
-        target = os.path.join(experiment_lesson_prefix, os.path.relpath(obj.key, "/".join([s3_root, experiments_dir, experiment_name, lesson_name])))
+    for obj in bucket.objects.filter(Prefix="/".join([s3_root, path_from_s3_root])):
+        target = os.path.join(path_from_s3_root, os.path.relpath(obj.key, "/".join([s3_root, path_from_s3_root])))
         print(f"Copy {obj.key} to {target}")
         if not os.path.exists(os.path.dirname(target)):
             os.makedirs(os.path.dirname(target))
@@ -275,7 +277,7 @@ def main():
                 exit(1)
             try:
                 s3 = boto3.resource("s3")
-                get_s3_experiment_folder(s3, experiment_lesson_prefix, options.experiment_name, lesson)
+                get_s3_folder(s3, experiment_lesson_prefix)
             except Exception as e:
                 print(f"Could not download experiment {options.experiment_name} lesson {lesson}")
                 logging.error(e)


### PR DESCRIPTION
This PR follows https://github.com/code-dot-org/aiproxy/pull/47 which made rubric tester pull lesson data from s3 instead of google drive. That PR put lesson data into `s3://cdo-ai/teaching_assistant/lessons-new/` . This PR does the following:
1. split `lessons-new` into separate "datasets" (labeled code samples) and "experiments" (ai config) directories in s3, so that these can vary independently of each other
2. rename lessons to match https://github.com/code-dot-org/code-dot-org/pull/56351

here is a peek at how it looks in s3:
```
Dave-MBP:~/Downloads/s3-cdo-ai$ aws s3 ls --recursive s3://cdo-ai/teaching_assistant/ | grep csd3-2023-L11
2024-02-07 22:23:07       1408 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/actual_labels.csv
2024-02-07 22:23:02        352 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_1.js
2024-02-07 22:23:03        352 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_10.js
2024-02-07 22:23:03        786 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_11.js
2024-02-07 22:23:06        711 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_12.js
2024-02-07 22:23:04        342 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_13.js
2024-02-07 22:23:05        696 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_14.js
2024-02-07 22:23:09        490 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_15.js
2024-02-07 22:23:08        532 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_16.js
2024-02-07 22:23:10        734 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_17.js
2024-02-07 22:23:11        705 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_18.js
2024-02-07 22:23:12        568 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_19.js
2024-02-07 22:23:13        700 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_2.js
2024-02-07 22:23:14        563 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_3.js
2024-02-07 22:23:15        605 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_4.js
2024-02-07 22:23:16        333 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_5.js
2024-02-07 22:23:17        503 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_6.js
2024-02-07 22:23:18        527 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_7.js
2024-02-07 22:23:19        483 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_8.js
2024-02-07 22:23:20        456 teaching_assistant/datasets/contractor-grades-batch-1-fall-2023/csd3-2023-L11/student_9.js
2024-02-07 14:10:12        174 teaching_assistant/experiments/ai-rubrics-pilot-baseline/csd3-2023-L11/confidence.json
2024-02-07 14:10:13        131 teaching_assistant/experiments/ai-rubrics-pilot-baseline/csd3-2023-L11/params.json
2024-02-07 14:10:13       1409 teaching_assistant/experiments/ai-rubrics-pilot-baseline/csd3-2023-L11/standard_rubric.csv
2024-02-07 14:10:13       3101 teaching_assistant/experiments/ai-rubrics-pilot-baseline/csd3-2023-L11/system_prompt.txt
...
```
other notes:

* "experiments" are similar to "releases" in that they both contain ai config. if an experiment is successful in improving accuracy, we would launch it by copying it to releases and then adding a `confidence.json` file.

* In the short term, the benefit of separating out datasets is that if we will be well positioned to deal with any changes to existing contractor labels as we discover mistakes. In this case, we must **create a new dataset rather than modifying the existing one**, and should give it a name indicating it is a minor rev off of the original.

* having the file structure be organized as datasets-then-lessons and experiments-then-lessons is definitely an opinion. my thinking was that this will make it easiest to run tests across all lessons, at the expense of some duplication in the case where we only need to make a very minor rev to one lesson. (for [example](https://github.com/code-dot-org/code-dot-org/pull/56432)). one thought here is that if we are doing an experiment on only one level or pulling in a new dataset for only one lesson, we can avoid some duplication by having some datasets or experiments which contain just one lesson rather than all 6.

## Testing story

* I was able to successfully run rubric tester by repeatedly running `python lib/assessment/rubric_tester.py -c -n 3 -t 0.2` on all lessons except L21. on L21 I ran into an error which I was able to confirm was pre-existing:
```
Exception: standard concepts do not match actual concepts:
['Algorithms and Control - Interaction Conditionals', 'Algorithms and Control - Looping Conditionals', 'Algorithms and Control - Player Control Conditionals', 'Modularity - Multiple Sprites', 'Program Development - Program Sequence', 'Variables']
['Algorithms and Control Structures', 'Program Development 2', 'Variables']
```

* `./bin/test.sh` is passing

## future work

* fix actual_labels.csv headers for L21

* make it so that rubric tester can be run against releases in addition to experiments
