### PR TITLE
always read from params.json when running rubric tester

### DIFF
--- a/lib/assessment/report.py
+++ b/lib/assessment/report.py
@@ -85,6 +85,8 @@ class Report:
 
     def generate_html_output(self, output_file, prompt, rubric, accuracy=None, predicted_labels=None, actual_labels=None, passing_labels=None, accuracy_by_criteria=None, errors=[], input_params={}, confusion_by_criteria=None, overall_confusion=None, label_names=None, prefix='sample_code'):
         link_base_url = f'file://{os.getcwd()}/{prefix}'
+        title_suffix = 'pass-fail' if passing_labels else 'exact-match'
+        doc_title = f"{input_params['lesson_name']}-{title_suffix}"
 
         with open(output_file, 'w+') as file:
             file.write('<!DOCTYPE html>\n')
@@ -92,7 +94,7 @@ class Report:
             file.write('<head>\n')
             file.write('  <meta charset="UTF-8">\n')
             file.write('  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n')
-            file.write('  <title>Rubric Test Results</title>\n')
+            file.write(f'  <title>{doc_title}</title>\n')
             file.write('</head>\n')
             file.write('<body style="-webkit-print-color-adjust: exact;">\n')
             file.write('  <h2>Prompt:</h2>\n')

--- a/lib/assessment/report.py
+++ b/lib/assessment/report.py
@@ -108,7 +108,8 @@ class Report:
                 file.write(f'  <p style="color: red">{", ".join(errors)} failed to load</p>\n')
 
             accuracy = 'N/A' if accuracy is None or math.isnan(accuracy) else f'{int(accuracy)}%'
-            file.write(f'  <h2>Overall Accuracy: {accuracy}</h2>\n')
+            report_type = 'Pass/Fail' if passing_labels else 'Exact Match'
+            file.write(f'  <h2>Overall Accuracy ({report_type}): {accuracy}</h2>\n')
             
             if accuracy_by_criteria is not None:
                 file.write('  <h2>Accuracy by Key Concept:</h2>\n')

--- a/lib/assessment/report.py
+++ b/lib/assessment/report.py
@@ -83,7 +83,7 @@ class Report:
         confusion_table += '</table>'
         return confusion_table
 
-    def generate_html_output(self, output_file, prompt, rubric, accuracy=None, predicted_labels=None, actual_labels=None, passing_labels=None, accuracy_by_criteria=None, errors=[], dataset_name=None, command_line=None, confusion_by_criteria=None, overall_confusion=None, label_names=None, prefix='sample_code'):
+    def generate_html_output(self, output_file, prompt, rubric, accuracy=None, predicted_labels=None, actual_labels=None, passing_labels=None, accuracy_by_criteria=None, errors=[], input_params={}, confusion_by_criteria=None, overall_confusion=None, label_names=None, prefix='sample_code'):
         link_base_url = f'file://{os.getcwd()}/{prefix}'
 
         with open(output_file, 'w+') as file:
@@ -99,17 +99,13 @@ class Report:
             file.write(f'  <pre>{prompt}</pre>\n')
             file.write('  <h2>Rubric:</h2>\n')
             file.write(self._rubric_to_html_table(rubric) + '\n')
+
+            file.write('  <h2>Input Params:</h2>\n')
+            file.write(f'  <pre>{json.dumps(input_params, indent=2)}</pre>\n')
+
             if len(errors) > 0:
                 file.write(f'  <h2 style="color: red">Errors: {len(errors)}</h2>\n')
                 file.write(f'  <p style="color: red">{", ".join(errors)} failed to load</p>\n')
-
-            if dataset_name:
-                file.write('  <h2>Dataset:</h2>\n')
-                file.write(f'  <pre>{dataset_name}</pre>\n')
-
-            if command_line:
-                file.write('  <h2>Command Line:</h2>\n')
-                file.write(f'  <pre>{command_line}</pre>\n')
 
             accuracy = 'N/A' if accuracy is None or math.isnan(accuracy) else f'{int(accuracy)}%'
             file.write(f'  <h2>Overall Accuracy: {accuracy}</h2>\n')

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -70,7 +70,6 @@ def command_line_options():
                         help='re-download lesson files, overwriting previous files')
     parser.add_argument('-a', '--accuracy', action='store_true',
                         help='Run against accuracy thresholds')
-    parser.add_argument('--params', action='store_true', help="Use params from lesson data files")
 
     args = parser.parse_args()
 
@@ -300,8 +299,7 @@ def main():
                 logging.error(e)
 
         # read in lesson files, validate them
-        if options.params:
-            params = get_params(experiment_lesson_prefix)
+        params = get_params(experiment_lesson_prefix)
         prompt, standard_rubric = read_inputs(prompt_file, standard_rubric_file, experiment_lesson_prefix)
         student_files = get_student_files(options.max_num_students, dataset_lesson_prefix, student_ids=options.student_ids)
         if os.path.exists(os.path.join(dataset_lesson_prefix, actual_labels_file_old)):

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -54,27 +54,24 @@ def command_line_options():
                         help='Output filename within output directory')
     parser.add_argument('-c', '--use-cached', action='store_true',
                         help='Use cached responses from the API.')
-    parser.add_argument('-l', '--llm-model', type=str, default=DEFAULT_MODEL,
-                        help=f"Which LLM model to use. Supported models: {', '.join(SUPPORTED_MODELS)}. Default: {DEFAULT_MODEL}")
-    parser.add_argument('-n', '--num-responses', type=int, default=1,
-                        help='Number of responses to generate for each student. Defaults to 1.')
+    parser.add_argument('-l', '--llm-model', type=str, default=None,
+                        help=f"Which LLM model to use. Supported models: {', '.join(SUPPORTED_MODELS)}. Defaults to required params.json value.")
+    parser.add_argument('-n', '--num-responses', type=int, default=None,
+                        help=F"Number of responses to generate for each student. Defaults to required params.json value.")
     parser.add_argument('-p', '--num-passing-labels', type=int,
                         help='Number of labels which are considered passing.')
     parser.add_argument('-s', '--max-num-students', type=int, default=100,
                         help='Maximum number of students to label. Defaults to 100 students.')
     parser.add_argument('--student-ids', type=str,
                         help='Comma-separated list of student ids to label. Defaults to all students.')
-    parser.add_argument('-t', '--temperature', type=float, default=0.0,
-                        help='Temperature of the LLM. Defaults to 0.0.')
+    parser.add_argument('-t', '--temperature', type=float, default=None,
+                        help=f"Temperature of the LLM. Defaults to required params.json value.")
     parser.add_argument('-d', '--download', action='store_true',
                         help='re-download lesson files, overwriting previous files')
     parser.add_argument('-a', '--accuracy', action='store_true',
                         help='Run against accuracy thresholds')
 
     args = parser.parse_args()
-
-    if args.llm_model not in SUPPORTED_MODELS:
-        raise Exception(f"Unsupported LLM model: {args.llm_model}. Supported models are: {', '.join(SUPPORTED_MODELS)}")
 
     args.passing_labels = get_passing_labels(args.num_passing_labels)
 
@@ -125,7 +122,7 @@ def get_params(prefix):
     return params
 
 def validate_params(params):
-    required_keys = ['model']
+    required_keys = ['model', 'num-responses', 'temperature']
     allowed_keys = ['model', 'num-responses', 'temperature', 'remove-comments', 'num-passing-grades']
     deprecated_keys = ['num-passing-grades']
     for k in required_keys:
@@ -258,9 +255,9 @@ def read_and_label_student_work(prompt, rubric, student_file, examples, options,
             examples=examples,
             use_cached=options.use_cached,
             write_cached=True,
-            num_responses=params['num-responses'] if 'num-responses' in params else options.num_responses,
-            temperature=params['temperature'] if 'temperature' in params else options.temperature,
-            llm_model=params['model'] if 'model' in params else options.llm_model,
+            num_responses=options.num_responses or params['num-responses'],
+            temperature=options.temperature or params['temperature'],
+            llm_model=options.llm_model or params['model'],
             remove_comments=params['remove-comments'] if 'remove-comments' in params else False,
             cache_prefix=prefix
         )

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -70,6 +70,8 @@ def command_line_options():
                         help='re-download lesson files, overwriting previous files')
     parser.add_argument('-a', '--accuracy', action='store_true',
                         help='Run against accuracy thresholds')
+    parser.add_argument('-r', '--remove-comments', action='store_true',
+                        help='Remove comments from student code before evaluating')
 
     args = parser.parse_args()
 
@@ -258,7 +260,7 @@ def read_and_label_student_work(prompt, rubric, student_file, examples, options,
             num_responses=options.num_responses or params['num-responses'],
             temperature=options.temperature or params['temperature'],
             llm_model=options.llm_model or params['model'],
-            remove_comments=params['remove-comments'] if 'remove-comments' in params else False,
+            remove_comments=options.remove_comments or params.get('remove-comments', False),
             cache_prefix=prefix
         )
     except InvalidResponseError as e:

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -50,8 +50,6 @@ def command_line_options():
                         help=f"Name of dataset directory in S3 to load from. Default: {DEFAULT_DATASET_NAME}.")
     parser.add_argument('-e', '--experiment-name', type=str, default=DEFAULT_EXPERIMENT_NAME,
                         help=f"Name of experiment directory in S3 to load from. Default: {DEFAULT_EXPERIMENT_NAME}.")
-    parser.add_argument('-o', '--output-filename', type=str, default='report.html',
-                        help='Output filename within output directory')
     parser.add_argument('-c', '--use-cached', action='store_true',
                         help='Use cached responses from the API.')
     parser.add_argument('-l', '--llm-model', type=str, default=None,
@@ -76,6 +74,8 @@ def command_line_options():
     args = parser.parse_args()
 
     args.passing_labels = get_passing_labels(args.num_passing_labels)
+
+    args.output_filename = 'report-pass-fail.html' if args.passing_labels else 'report-exact-match.html'
 
     if args.student_ids:
         args.student_ids = args.student_ids.split(',')

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -113,6 +113,7 @@ def get_params(prefix):
     params = {}
     with open(os.path.join(prefix, params_file), 'r') as f:
         params = json.load(f)
+        validate_params(params)
         for k in params.keys():
             if k == 'model':
                 continue
@@ -122,6 +123,21 @@ def get_params(prefix):
                 params[k] = int(params[k])
             
     return params
+
+def validate_params(params):
+    required_keys = ['model']
+    allowed_keys = ['model', 'num-responses', 'temperature', 'remove-comments', 'num-passing-grades']
+    deprecated_keys = ['num-passing-grades']
+    for k in required_keys:
+        if k not in params:
+            raise Exception(f"Missing required key {k} in params.json")
+    for k in params.keys():
+        if k not in allowed_keys:
+            raise Exception(f"Unsupported key {k} in params.json. Supported keys are: {', '.join(allowed_keys)}")
+        if k in deprecated_keys:
+            logging.info(f"Deprecated key {k} in params.json. Please remove as this key has no effect.")
+    if params['model'] not in SUPPORTED_MODELS:
+        raise Exception(f"Unsupported LLM model: {params['model']}. Supported models are: {', '.join(SUPPORTED_MODELS)}")
 
 def get_student_files(max_num_students, prefix, student_ids=None):
     if student_ids:

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -55,7 +55,7 @@ def command_line_options():
     parser.add_argument('-l', '--llm-model', type=str, default=None,
                         help=f"Which LLM model to use. Supported models: {', '.join(SUPPORTED_MODELS)}. Defaults to required params.json value.")
     parser.add_argument('-n', '--num-responses', type=int, default=None,
-                        help=F"Number of responses to generate for each student. Defaults to required params.json value.")
+                        help='Number of responses to generate for each student. Defaults to required params.json value.')
     parser.add_argument('-p', '--num-passing-labels', type=int,
                         help='Number of labels which are considered passing.')
     parser.add_argument('-s', '--max-num-students', type=int, default=100,
@@ -63,7 +63,7 @@ def command_line_options():
     parser.add_argument('--student-ids', type=str,
                         help='Comma-separated list of student ids to label. Defaults to all students.')
     parser.add_argument('-t', '--temperature', type=float, default=None,
-                        help=f"Temperature of the LLM. Defaults to required params.json value.")
+                        help='Temperature of the LLM. Defaults to required params.json value.')
     parser.add_argument('-d', '--download', action='store_true',
                         help='re-download lesson files, overwriting previous files')
     parser.add_argument('-a', '--accuracy', action='store_true',

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -347,6 +347,17 @@ def main():
         accuracy_by_criteria, overall_accuracy, confusion_by_criteria, overall_confusion, label_names = compute_accuracy(actual_labels, predicted_labels, options.passing_labels)
         overall_accuracy_percent = overall_accuracy * 100
         accuracy_by_criteria_percent = {k:v*100 for k,v in accuracy_by_criteria.items()}
+        input_params = {
+            "dataset_name": options.dataset_name,
+            "experiment_name": options.experiment_name,
+            "lesson_name": lesson,
+            "model_params": {
+                "model": options.llm_model or params['model'],
+                "num_responses": options.num_responses or params['num-responses'],
+                "temperature": options.temperature or params['temperature'],
+                "remove_comments": options.remove_comments or params.get('remove-comments', False)
+            }
+        }
         report = Report()
         report.generate_html_output(
             output_file,
@@ -358,8 +369,7 @@ def main():
             passing_labels=options.passing_labels,
             accuracy_by_criteria=accuracy_by_criteria_percent,
             errors=errors,
-            dataset_name=options.dataset_name,
-            command_line=command_line,
+            input_params=input_params,
             confusion_by_criteria=confusion_by_criteria,
             overall_confusion=overall_confusion,
             label_names=label_names,

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -258,10 +258,10 @@ def read_and_label_student_work(prompt, rubric, student_file, examples, options,
             examples=examples,
             use_cached=options.use_cached,
             write_cached=True,
-            num_responses=params['num_responses'] if 'num_responses' in params else options.num_responses,
+            num_responses=params['num-responses'] if 'num-responses' in params else options.num_responses,
             temperature=params['temperature'] if 'temperature' in params else options.temperature,
             llm_model=params['model'] if 'model' in params else options.llm_model,
-            remove_comments=params['remove_comments'] if 'remove_comments' in params else False,
+            remove_comments=params['remove-comments'] if 'remove-comments' in params else False,
             cache_prefix=prefix
         )
     except InvalidResponseError as e:

--- a/tests/unit/assessment/test_report.py
+++ b/tests/unit/assessment/test_report.py
@@ -66,7 +66,7 @@ class TestGenerateHtmlOutput:
             prompt,
             rubric,
             accuracy=42.0,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         mock_file.assert_called_with(output_file, 'w+')
@@ -84,7 +84,7 @@ class TestGenerateHtmlOutput:
             prompt,
             rubric,
             accuracy=42.0,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         output = self._get_output(mock_file)
@@ -106,7 +106,7 @@ class TestGenerateHtmlOutput:
             prompt,
             rubric,
             accuracy=42.0,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         output = self._get_output(mock_file)
@@ -128,12 +128,12 @@ class TestGenerateHtmlOutput:
             output_file,
             prompt,
             rubric,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         output = self._get_output(mock_file)
 
-        assert "Accuracy: N/A" in output
+        assert "Accuracy (Exact Match): N/A" in output
 
     def test_should_report_accuracy_table(self, mocker, report, prompt, rubric, randomstring):
         # Generate a random output filename
@@ -164,7 +164,7 @@ class TestGenerateHtmlOutput:
             prompt,
             rubric,
             accuracy_by_criteria=accuracy_by_criteria,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         output = self._get_output(mock_file)
@@ -196,7 +196,7 @@ class TestGenerateHtmlOutput:
             output_file,
             prompt,
             rubric,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
             overall_confusion=overall_confusion,
             confusion_by_criteria=confusion_by_criteria,
             label_names=labels,
@@ -243,7 +243,7 @@ class TestGenerateHtmlOutput:
             rubric,
             predicted_labels=predicted_labels,
             actual_labels=actual_labels,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         output = self._get_output(mock_file)
@@ -292,7 +292,7 @@ class TestGenerateHtmlOutput:
             predicted_labels=predicted_labels,
             actual_labels=actual_labels,
             passing_labels=passing_labels,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         output = self._get_output(mock_file)
@@ -321,7 +321,7 @@ class TestGenerateHtmlOutput:
             prompt,
             rubric,
             errors=errors,
-            command_line="./assess.py",
+            input_params={'lesson_name': 'my-lesson'},
         )
 
         output = self._get_output(mock_file)

--- a/tests/unit/assessment/test_rubric_tester.py
+++ b/tests/unit/assessment/test_rubric_tester.py
@@ -23,7 +23,7 @@ from lib.assessment.label import Label, InvalidResponseError
 
 
 class TestLabelStudentWork:
-    def test_should_pass_arguments_through(self, mocker, code, prompt, rubric, examples, student_id, temperature, llm_model):
+    def test_should_pass_arguments_through(self, mocker, code, prompt, rubric, examples, student_id, temperature, llm_model, remove_comments):
         label_student_work_mock = mocker.patch.object(Label, 'label_student_work')
 
         # Mock the file read
@@ -35,7 +35,8 @@ class TestLabelStudentWork:
             write_cached=False,
             num_responses=random.randint(1, 3),
             temperature=temperature,
-            llm_model=llm_model
+            llm_model=llm_model,
+            remove_comments=remove_comments
         )
 
         labels = ['good data']


### PR DESCRIPTION
FInishes [AITT-451](https://codedotorg.atlassian.net/browse/AITT-451). This PR makes many small tweaks to rubric tester params to get it ready to do a bunch of accuracy runs, most notably by fixing up the use of params.json and making it read from that file by default. 

I've also included some visible changes to make sure the report is easier to use and has all the necessary info. see commit list for details. the visible changes can be seen here:
![Screenshot 2024-02-12 at 5 20 47 PM](https://github.com/code-dot-org/aiproxy/assets/8001765/8063fe3b-eb32-4766-909c-d2113941af7d)

if i missed any info that should be included here please let me know 😁 

With this change, it's now possible to generate accuracy reports for an entire experiment via a single command `python ./lib/assessment/rubric_tester.py --experiment_name=...`.

## Testing story

I used the new input_params output to manually verify that the params.json params and their command line overrides are working as expected.

## Future work

up next: accuracy improvements!