### PR TITLE
Rename tsv_data to response_data

### DIFF
--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -74,7 +74,7 @@ class Label:
 
         info = response.json()
 
-        tsv_data = self.tsv_data_from_choices(info, rubric, student_id)
+        tsv_data = self.response_data_from_choices(info, rubric, student_id)
 
         return {
             'metadata': {
@@ -158,7 +158,7 @@ class Label:
 
         return student_code
 
-    def tsv_data_from_choices(self, info, rubric, student_id):
+    def response_data_from_choices(self, info, rubric, student_id):
         max_index = len(info['choices']) - 1
         tsv_data_choices = []
         for index, choice in enumerate(info['choices']):

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -207,6 +207,7 @@ class Label:
                 raise e
             return None
 
+    # parse response data in tsv, csv or markdown format.
     def parse_non_json_response(self, text):
         # Remove anything up to the first column name
         if "\nKey Concept" in text:

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -74,7 +74,7 @@ class Label:
 
         info = response.json()
 
-        tsv_data = self.response_data_from_choices(info, rubric, student_id)
+        response_data = self.response_data_from_choices(info, rubric, student_id)
 
         return {
             'metadata': {
@@ -82,7 +82,7 @@ class Label:
                 'usage': info['usage'],
                 'request': data,
             },
-            'data': tsv_data,
+            'data': response_data,
         }
 
     def label_student_work(self, prompt, rubric, student_code, student_id, examples=[], use_cached=False, write_cached=False, num_responses=0, temperature=0.0, llm_model="", remove_comments=False, cache_prefix=""):
@@ -166,17 +166,17 @@ class Label:
             reraise = len(response_data_choices) == 0 and index == max_index
 
             if choice['message']['content']:
-                tsv_data = self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index, reraise=reraise)
-                if tsv_data:
-                    response_data_choices.append(tsv_data)
+                response_data = self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index, reraise=reraise)
+                if response_data:
+                    response_data_choices.append(response_data)
 
         if len(response_data_choices) == 0:
             raise InvalidResponseError("No valid responses. An InvalidResponseError should have been raised earlier.")
         elif len(response_data_choices) == 1:
-            tsv_data = response_data_choices[0]
+            response_data = response_data_choices[0]
         else:
-            tsv_data = self.get_consensus_response(response_data_choices, student_id)
-        return tsv_data
+            response_data = self.get_consensus_response(response_data_choices, student_id)
+        return response_data
 
     def compute_messages(self, prompt, rubric, student_code, examples=[]):
         messages = [
@@ -217,28 +217,28 @@ class Label:
                 text = "\n".join(lines)
                 logging.info("response was markdown and not tsv, delimiting by '|'")
 
-                tsv_data = list(csv.DictReader(StringIO(text), delimiter='|'))
+                response_data = list(csv.DictReader(StringIO(text), delimiter='|'))
             else:
                 # Let's assume it is CSV
                 logging.info("response had no tabs so is not tsv, delimiting by ','")
-                tsv_data = list(csv.DictReader(StringIO(text), delimiter=','))
+                response_data = list(csv.DictReader(StringIO(text), delimiter=','))
         else:
             # Let's assume it is TSV
-            tsv_data = list(csv.DictReader(StringIO(text), delimiter='\t'))
+            response_data = list(csv.DictReader(StringIO(text), delimiter='\t'))
 
         try:
-            self._sanitize_server_response(tsv_data)
-            self._validate_server_response(tsv_data, rubric)
-            return [row for row in tsv_data]
+            self._sanitize_server_response(response_data)
+            self._validate_server_response(response_data, rubric)
+            return [row for row in response_data]
         except InvalidResponseError as e:
             logging.error(f"{student_id} {choice_text} Invalid response: {str(e)}\n{response_text}")
             if reraise:
                 raise e
             return None
 
-    def _sanitize_server_response(self, tsv_data):
+    def _sanitize_server_response(self, response_data):
         # Strip whitespace and quotes from fields
-        for row in tsv_data:
+        for row in response_data:
             for key in list(row.keys()):
                 if isinstance(row[key], str):
                     row[key] = row[key].strip().strip('"')
@@ -249,28 +249,28 @@ class Label:
                         del row[key]
 
         # Remove rows that don't start with reasonable things
-        for row in tsv_data:
+        for row in response_data:
             if "Key Concept" in row:
                 if not row["Key Concept"][0:1].isalnum():
-                    tsv_data.remove(row)
+                    response_data.remove(row)
 
-        for row in tsv_data:
+        for row in response_data:
             if "Grade" in row.keys():
                 row['Label'] = row['Grade']
                 del row['Grade']
 
-    def _validate_server_response(self, tsv_data, rubric):
+    def _validate_server_response(self, response_data, rubric):
         expected_columns = ["Key Concept", "Observations", "Label", "Reason"]
 
         rubric_key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
 
-        if not all((set(row.keys()) & set(expected_columns)) == set(expected_columns) for row in tsv_data):
-            for row in tsv_data:
+        if not all((set(row.keys()) & set(expected_columns)) == set(expected_columns) for row in response_data):
+            for row in response_data:
                 unexpected_columns = set(row.keys()) - set(expected_columns)
                 missing_columns = set(expected_columns) - set(row.keys())
                 raise InvalidResponseError(f'incorrect column names. unexpected: {unexpected_columns} missing: {missing_columns}')
 
-        key_concepts_from_response = list(set(row["Key Concept"] for row in tsv_data))
+        key_concepts_from_response = list(set(row["Key Concept"] for row in response_data))
         if sorted(rubric_key_concepts) != sorted(key_concepts_from_response):
             unexpected_concepts = set(key_concepts_from_response) - set(rubric_key_concepts)
             unexpected_concepts = None if len(unexpected_concepts) == 0 else unexpected_concepts
@@ -278,7 +278,7 @@ class Label:
             missing_concepts = None if len(missing_concepts) == 0 else missing_concepts
             raise InvalidResponseError(f'unexpected or missing key concept. unexpected: {unexpected_concepts} missing: {missing_concepts}')
 
-        for row in tsv_data:
+        for row in response_data:
             if row['Label'] not in VALID_LABELS:
                 raise InvalidResponseError(f"invalid label value: '{row['Label']}'")
 

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -166,7 +166,7 @@ class Label:
             reraise = len(response_data_choices) == 0 and index == max_index
 
             if choice['message']['content']:
-                response_data = self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index, reraise=reraise)
+                response_data = self.get_response_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index, reraise=reraise)
                 if response_data:
                     response_data_choices.append(response_data)
 
@@ -188,7 +188,7 @@ class Label:
         messages.append({'role': 'user', 'content': student_code})
         return messages
 
-    def get_tsv_data_if_valid(self, response_text, rubric, student_id, choice_index=None, reraise=False):
+    def get_response_data_if_valid(self, response_text, rubric, student_id, choice_index=None, reraise=False):
         choice_text = f"Choice {choice_index}: " if choice_index is not None else ''
         if not response_text:
             logging.error(f"{student_id} {choice_text} Invalid response: empty response")

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -160,22 +160,22 @@ class Label:
 
     def response_data_from_choices(self, info, rubric, student_id):
         max_index = len(info['choices']) - 1
-        tsv_data_choices = []
+        response_data_choices = []
         for index, choice in enumerate(info['choices']):
             # If all choices result in an InvalidResponseError, reraise the last one.
-            reraise = len(tsv_data_choices) == 0 and index == max_index
+            reraise = len(response_data_choices) == 0 and index == max_index
 
             if choice['message']['content']:
                 tsv_data = self.get_tsv_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index, reraise=reraise)
                 if tsv_data:
-                    tsv_data_choices.append(tsv_data)
+                    response_data_choices.append(tsv_data)
 
-        if len(tsv_data_choices) == 0:
+        if len(response_data_choices) == 0:
             raise InvalidResponseError("No valid responses. An InvalidResponseError should have been raised earlier.")
-        elif len(tsv_data_choices) == 1:
-            tsv_data = tsv_data_choices[0]
+        elif len(response_data_choices) == 1:
+            tsv_data = response_data_choices[0]
         else:
-            tsv_data = self.get_consensus_response(tsv_data_choices, student_id)
+            tsv_data = self.get_consensus_response(response_data_choices, student_id)
         return tsv_data
 
     def compute_messages(self, prompt, rubric, student_code, examples=[]):

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -626,7 +626,7 @@ class TestlabelStudentWork:
 
 class TestGetConsensusResponse:
     @pytest.fixture
-    def tsv_data_choices(self, label, openai_gpt_response):
+    def response_data_choices(self, label, openai_gpt_response):
         def gen_tsv_data_choices(rubric, student_id, num_responses=3, disagreements=1):
             # Disagreements always happen in the first choice... so they always
             # mean an 'outvote'
@@ -637,8 +637,8 @@ class TestGetConsensusResponse:
 
         yield gen_tsv_data_choices
 
-    def test_should_coalesce_votes(self, label, tsv_data_choices, rubric, student_id):
-        choices = tsv_data_choices(rubric, student_id)
+    def test_should_coalesce_votes(self, label, response_data_choices, rubric, student_id):
+        choices = response_data_choices(rubric, student_id)
         result = label.get_consensus_response(choices, student_id)
 
         # It should have the same number of rows as the rubric has key concepts
@@ -661,10 +661,10 @@ class TestGetConsensusResponse:
         # in the choice list.
         assert all(labels[entry['Key Concept']].count(entry['Label']) >= 2 for entry in result)
 
-    def test_should_log_outvoting(self, caplog, label, tsv_data_choices, rubric, student_id):
+    def test_should_log_outvoting(self, caplog, label, response_data_choices, rubric, student_id):
         caplog.set_level(logging.INFO)
 
-        choices = tsv_data_choices(rubric, student_id)
+        choices = response_data_choices(rubric, student_id)
         result = label.get_consensus_response(choices, student_id)
 
         # It should have the same number of rows as the rubric has key concepts
@@ -672,12 +672,12 @@ class TestGetConsensusResponse:
 
         assert any(filter(lambda x: (f'outvoted {student_id}' in x.message) and x.levelno == logging.INFO, caplog.records))
 
-    def test_reason_should_include_disagreeing_votes(self, label, tsv_data_choices, short_rubric, student_id):
-        choices = tsv_data_choices(short_rubric, student_id, num_responses=3, disagreements=1)
+    def test_reason_should_include_disagreeing_votes(self, label, response_data_choices, short_rubric, student_id):
+        choices = response_data_choices(short_rubric, student_id, num_responses=3, disagreements=1)
         result = label.get_consensus_response(choices, student_id)
         assert 'Votes' in result[0]['Reason']
 
-    def test_reason_should_exclude_agreeing_votes(self, label, tsv_data_choices, short_rubric, student_id):
-        choices = tsv_data_choices(short_rubric, student_id, num_responses=3, disagreements=0)
+    def test_reason_should_exclude_agreeing_votes(self, label, response_data_choices, short_rubric, student_id):
+        choices = response_data_choices(short_rubric, student_id, num_responses=3, disagreements=0)
         result = label.get_consensus_response(choices, student_id)
         assert 'Votes' not in result[0]['Reason']

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -627,7 +627,7 @@ class TestlabelStudentWork:
 class TestGetConsensusResponse:
     @pytest.fixture
     def response_data_choices(self, label, openai_gpt_response):
-        def gen_tsv_data_choices(rubric, student_id, num_responses=3, disagreements=1):
+        def gen_response_data_choices(rubric, student_id, num_responses=3, disagreements=1):
             # Disagreements always happen in the first choice... so they always
             # mean an 'outvote'
             ai_response = openai_gpt_response(rubric, num_responses=num_responses, disagreements=disagreements, output_type='tsv')
@@ -635,7 +635,7 @@ class TestGetConsensusResponse:
             # return [list(csv.DictReader(StringIO(x), delimiter='\t')) for x in responses]
             return responses
 
-        yield gen_tsv_data_choices
+        yield gen_response_data_choices
 
     def test_should_coalesce_votes(self, label, response_data_choices, rubric, student_id):
         choices = response_data_choices(rubric, student_id)

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -127,13 +127,13 @@ class TestComputeMessages:
 
 class TestGetTsvDataIfValid:
     def test_should_return_none_if_the_response_is_blank(self, label, rubric, student_id):
-        result = label.get_tsv_data_if_valid("", rubric, student_id)
+        result = label.get_response_data_if_valid("", rubric, student_id)
 
         assert result is None
 
     def test_should_log_the_choice_index_if_the_response_is_blank(self, caplog, label, rubric, student_id):
         index = random.randint(0, 5)
-        label.get_tsv_data_if_valid("", rubric, student_id, choice_index=index)
+        label.get_response_data_if_valid("", rubric, student_id, choice_index=index)
 
         assert any(filter(lambda x: (f'Choice {index}' in x.message) and x.levelno == logging.ERROR, caplog.records))
 
@@ -147,7 +147,7 @@ class TestGetTsvDataIfValid:
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
         # It should parse them out to get the same number of rows as the rubric
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
@@ -161,7 +161,7 @@ class TestGetTsvDataIfValid:
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
         # It should parse them out to get the same number of rows as the rubric
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
@@ -173,7 +173,7 @@ class TestGetTsvDataIfValid:
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
         # It should parse them out to get the same number of rows as the rubric
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
@@ -188,7 +188,7 @@ class TestGetTsvDataIfValid:
 
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
@@ -207,7 +207,7 @@ class TestGetTsvDataIfValid:
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
         # Should be fine
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
@@ -225,7 +225,7 @@ class TestGetTsvDataIfValid:
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
         # Should be fine
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
@@ -238,7 +238,7 @@ class TestGetTsvDataIfValid:
         # We can invalidate the response
         response = response.replace("Key Concept", "Bogus Weasel")
 
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is None
 
     def test_should_return_none_when_the_columns_are_invalid(self, mocker, label, rubric, student_id, openai_gpt_response):
@@ -250,7 +250,7 @@ class TestGetTsvDataIfValid:
         # We can invalidate the response
         response = response.replace("Observations", "Things I notice")
 
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is None
 
     def test_should_return_none_when_a_key_concept_is_missing(self, mocker, label, rubric, student_id, openai_gpt_response):
@@ -266,7 +266,7 @@ class TestGetTsvDataIfValid:
 
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is None
 
     def test_should_return_none_when_a_different_key_concept_is_found(self, mocker, label, rubric, student_id, openai_gpt_response):
@@ -285,7 +285,7 @@ class TestGetTsvDataIfValid:
 
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is None
 
     def test_should_return_none_when_there_is_an_invalid_label(self, mocker, label, rubric, student_id, openai_gpt_response):
@@ -305,7 +305,7 @@ class TestGetTsvDataIfValid:
 
         parsed_rubric = list(csv.DictReader(rubric.splitlines()))
 
-        result = label.get_tsv_data_if_valid(response, rubric, student_id)
+        result = label.get_response_data_if_valid(response, rubric, student_id)
         assert result is None
 
 
@@ -349,7 +349,7 @@ class TestAiLabelStudentWork:
         )
 
         # Mock the validator to invalidate everything
-        mocker.patch.object(Label, 'get_tsv_data_if_valid').return_value = None
+        mocker.patch.object(Label, 'get_response_data_if_valid').return_value = None
 
         with pytest.raises(InvalidResponseError):
             label.ai_label_student_work(
@@ -631,7 +631,7 @@ class TestGetConsensusResponse:
             # Disagreements always happen in the first choice... so they always
             # mean an 'outvote'
             ai_response = openai_gpt_response(rubric, num_responses=num_responses, disagreements=disagreements, output_type='tsv')
-            responses = [label.get_tsv_data_if_valid(x['message']['content'], rubric, student_id) for x in ai_response['choices']]
+            responses = [label.get_response_data_if_valid(x['message']['content'], rubric, student_id) for x in ai_response['choices']]
             # return [list(csv.DictReader(StringIO(x), delimiter='\t')) for x in responses]
             return responses
 


### PR DESCRIPTION
Bite-size refactor PR to prepare for adding support for receiving LLM responses in JSON format.

* Renames tsv_data to response_data in various places. In every case, the data being stored is an array of python objects, not tsv. 
* also extracts `parse_non_json_response` helper method

### Testing story

`bin/test.sh` is passing