### PR TITLE
Use AWS managed policy instead of creating one

### DIFF
--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -131,28 +131,8 @@ Resources:
                 - ecs-tasks.amazonaws.com
             Action:
               - sts:AssumeRole
-      Policies:
-        - PolicyName: ECRPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ecr:GetAuthorizationToken
-                  - ecr:BatchCheckLayerAvailability
-                  - ecr:GetDownloadUrlForLayer
-                  - ecr:BatchGetImage
-                Resource: "*"
-        - PolicyName: LogsPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogGroup
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: "*"
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
 
 Outputs:
   CodeBuildArtifactBucket:


### PR DESCRIPTION
The AWS managed policy is identical to this manual one, with the exception of CreateLogGroup, which we don't need.