### PR TITLE
save load balancer logs

### DIFF
--- a/cicd/3-app/aiproxy/template.yml
+++ b/cicd/3-app/aiproxy/template.yml
@@ -63,6 +63,14 @@ Resources:
       LoadBalancerAttributes:
         - Key: idle_timeout.timeout_seconds
           Value: 180
+        - Key: access_logs.s3.enabled
+          Value: true
+        - Key: access_logs.s3.bucket
+          Value: cdo-logs
+        - Key: access_logs.s3.prefix
+          Value: !Sub ${AWS::StackName}-alb-access-logs
+        - Key: waf.fail_open.enabled
+          Value: true
       SecurityGroups:
         - !ImportValue VPC-ELBSecurityGroup
       Subnets:


### PR DESCRIPTION
We currently see some odd traffic to this service. Save load-balancer logs to the `cdo-logs` bucket for analysis.

## Follow Up Work

* Manually set a lifecycle rule on the cdo-logs bucket to trash the `aiproxy-test-alb-access-logs` path (or any non-prod logs) after 90 days
* Via Cloudformation, associate this ALB with a WAF ACL. As a public entrypoint, we should apply DDOS protection.