### PR TITLE
add rubric tester option to generate confidence.json and confidence-exact.json

### DIFF
--- a/lib/assessment/confidence.py
+++ b/lib/assessment/confidence.py
@@ -1,0 +1,20 @@
+import json
+import logging
+import os
+
+def get_pass_fail_confidence(accuracy: dict) -> str:
+    """
+    This function takes a dictionary of learning goals and their respective accuracies and returns a dictionary of
+    learning goals and their respective confidence levels.
+    """
+    confidence = {}
+
+    for learning_goal in accuracy:
+        if accuracy[learning_goal] >= 0.85:
+            confidence[learning_goal] = "HIGH"
+        elif accuracy[learning_goal] >= 0.8:
+            confidence[learning_goal] = "MEDIUM"
+        else:
+            confidence[learning_goal] = "LOW"
+
+    return confidence

--- a/lib/assessment/confidence.py
+++ b/lib/assessment/confidence.py
@@ -1,6 +1,9 @@
 import json
 import logging
 import os
+import numpy as np
+
+from lib.assessment.config import VALID_LABELS
 
 def get_pass_fail_confidence(accuracy: dict) -> str:
     """
@@ -18,3 +21,38 @@ def get_pass_fail_confidence(accuracy: dict) -> str:
             confidence[learning_goal] = "LOW"
 
     return confidence
+
+
+def get_exact_match_confidence(confusion_by_criteria: dict) -> dict:
+    """
+    This function takes a dictionary of confusion matrices and returns a nested dictionary of learning goals and
+    evidence levels mapped to their respective confidence levels.
+    """
+    confidence = {}
+
+    for learning_goal in confusion_by_criteria:
+        confidence[learning_goal] = {}
+        confusion = confusion_by_criteria[learning_goal]
+        counts, accuracies = get_predicted_class_stats(confusion)
+        for i in range(len(VALID_LABELS)):
+            label = VALID_LABELS[i]
+            if accuracies[i] >= 0.88 and counts[i] >= 10:
+                confidence[learning_goal][label] = "HIGH"
+            else:
+                confidence[learning_goal][label] = "LOW"
+
+    return confidence
+
+def get_predicted_class_stats(confusion):
+    """
+    compute count and accuracy for each predicted class (column) in the confusion matrix
+    """
+    counts = []
+    accuracies = []
+
+    for i in range(len(confusion)):
+        col_sum = np.sum(confusion[:, i])
+        counts.append(col_sum)
+        accuracies.append(confusion[i, i] / col_sum if col_sum > 0 else 0)
+
+    return counts, accuracies

--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -1,4 +1,7 @@
 VALID_LABELS = ["Extensive Evidence", "Convincing Evidence", "Limited Evidence", "No Evidence"]
+
+PASSING_LABELS = VALID_LABELS[:2]
+
 # do not include gpt-4, so that we always know what version of the model we are using.
 SUPPORTED_MODELS = [
     'bedrock.anthropic.claude-v2',

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -411,13 +411,13 @@ def main():
         if options.generate_confidence:
             confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
             with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
-                json.dump(confidence_pass_fail, f, indent=4)
+                json.dump(confidence_pass_fail, f, indent=2)
                 f.write('\n')
                 logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence.json')}")
 
             confidence_exact_match = get_exact_match_confidence(confusion_by_criteria)
             with open(os.path.join(experiment_lesson_prefix, 'confidence-exact.json'), 'w') as f:
-                json.dump(confidence_exact_match, f, indent=4)
+                json.dump(confidence_exact_match, f, indent=2)
                 f.write('\n')
                 logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence-exact.json')}")
 

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -408,20 +408,22 @@ def main():
 
         os.system(f"open {output_file}")
 
+        if options.generate_confidence:
+            confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
+            with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
+                json.dump(confidence_pass_fail, f, indent=4)
+                f.write('\n')
+                logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence.json')}")
+
+            confidence_exact_match = get_exact_match_confidence(confusion_by_criteria)
+            with open(os.path.join(experiment_lesson_prefix, 'confidence-exact.json'), 'w') as f:
+                json.dump(confidence_exact_match, f, indent=4)
+                f.write('\n')
+                logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence-exact.json')}")
+
     if not accuracy_pass and len(accuracy_failures.keys()) > 0:
         logging.error(f"The following thresholds were not met:\n{pp.pformat(accuracy_failures)}")
         print(("PASS" if accuracy_pass else "FAIL"))
-
-    if options.generate_confidence:
-        confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
-        with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
-            json.dump(confidence_pass_fail, f, indent=4)
-            f.write('\n')
-
-        confidence_exact_match = get_exact_match_confidence(confusion_by_criteria)
-        with open(os.path.join(experiment_lesson_prefix, 'confidence-exact.json'), 'w') as f:
-            json.dump(confidence_exact_match, f, indent=4)
-            f.write('\n')
 
     return accuracy_pass
 

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -57,8 +57,6 @@ def command_line_options():
                         help=f"Which LLM model to use. Supported models: {', '.join(SUPPORTED_MODELS)}. Defaults to required params.json value.")
     parser.add_argument('-n', '--num-responses', type=int, default=None,
                         help='Number of responses to generate for each student. Defaults to required params.json value.')
-    parser.add_argument('-p', '--num-passing-labels', type=int,
-                        help='Number of labels which are considered passing.')
     parser.add_argument('-s', '--max-num-students', type=int, default=100,
                         help='Maximum number of students to label. Defaults to 100 students.')
     parser.add_argument('--student-ids', type=str,
@@ -75,8 +73,6 @@ def command_line_options():
                         help='Generate confidence levels for each learning goal')
 
     args = parser.parse_args()
-
-    args.passing_labels = get_passing_labels(args.num_passing_labels)
 
     if args.student_ids:
         args.student_ids = args.student_ids.split(',')

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -20,7 +20,7 @@ import subprocess
 from sklearn.metrics import accuracy_score, confusion_matrix
 from collections import defaultdict
 
-from lib.assessment.config import SUPPORTED_MODELS, DEFAULT_MODEL, VALID_LABELS, LESSONS, DEFAULT_DATASET_NAME, DEFAULT_EXPERIMENT_NAME
+from lib.assessment.config import SUPPORTED_MODELS, DEFAULT_MODEL, VALID_LABELS, PASSING_LABELS, LESSONS, DEFAULT_DATASET_NAME, DEFAULT_EXPERIMENT_NAME
 from lib.assessment.label import Label, InvalidResponseError, RequestTooLargeError
 from lib.assessment.report import Report
 from lib.assessment.confidence import get_pass_fail_confidence, get_exact_match_confidence
@@ -341,7 +341,7 @@ def main():
         predicted_labels = {student_id: labels['data'] for student_id, labels in predicted_labels if labels}
 
         for is_pass_fail in [True, False]:
-            passing_labels = VALID_LABELS[:2] if is_pass_fail else None
+            passing_labels = PASSING_LABELS if is_pass_fail else None
 
             output_filename = 'report-pass-fail.html' if is_pass_fail else 'report-exact-match.html'
             output_file = os.path.join(experiment_lesson_prefix, output_dir_name, output_filename)

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -88,14 +88,6 @@ def command_line_options():
 
     return args
 
-
-def get_passing_labels(num_passing_labels):
-    if num_passing_labels:
-        return VALID_LABELS[:num_passing_labels]
-    else:
-        return None
-
-
 def read_inputs(prompt_file, standard_rubric_file, prefix):
     with open(os.path.join(prefix, prompt_file), 'r') as f:
         prompt = f.read()

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 from lib.assessment.config import SUPPORTED_MODELS, DEFAULT_MODEL, VALID_LABELS, LESSONS, DEFAULT_DATASET_NAME, DEFAULT_EXPERIMENT_NAME
 from lib.assessment.label import Label, InvalidResponseError, RequestTooLargeError
 from lib.assessment.report import Report
+from lib.assessment.confidence import get_pass_fail_confidence
 
 #globals
 prompt_file = 'system_prompt.txt'
@@ -70,6 +71,8 @@ def command_line_options():
                         help='Run against accuracy thresholds')
     parser.add_argument('-r', '--remove-comments', action='store_true',
                         help='Remove comments from student code before evaluating')
+    parser.add_argument('-g', '--generate-confidence', action='store_true',
+                        help='Generate confidence levels for each learning goal')
 
     args = parser.parse_args()
 
@@ -408,6 +411,11 @@ def main():
     if not accuracy_pass and len(accuracy_failures.keys()) > 0:
         logging.error(f"The following thresholds were not met:\n{pp.pformat(accuracy_failures)}")
         print(("PASS" if accuracy_pass else "FAIL"))
+
+    if options.generate_confidence:
+        confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
+        with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
+            json.dump(confidence_pass_fail, f, indent=4)
 
     return accuracy_pass
 

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -355,7 +355,7 @@ def main():
         for is_pass_fail in [True, False]:
             passing_labels = VALID_LABELS[:2] if is_pass_fail else None
 
-            output_filename = 'report-pass-fail.html' if passing_labels else 'report-exact-match.html'
+            output_filename = 'report-pass-fail.html' if is_pass_fail else 'report-exact-match.html'
             output_file = os.path.join(experiment_lesson_prefix, output_dir_name, output_filename)
 
             # calculate accuracy and generate report
@@ -393,7 +393,7 @@ def main():
             )
             logging.info(f"lesson {lesson} finished in {int(time.time() - main_start_time)} seconds")
 
-            if options.accuracy and accuracy_thresholds is not None and passing_labels is None:
+            if options.accuracy and accuracy_thresholds is not None and not is_pass_fail:
                 if overall_accuracy < accuracy_thresholds[lesson]['overall']:
                     accuracy_pass = False
                     accuracy_failures[lesson] = {}
@@ -412,7 +412,7 @@ def main():
             os.system(f"open {output_file}")
 
             if options.generate_confidence:
-                if passing_labels:
+                if is_pass_fail:
                     confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
                     with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
                         json.dump(confidence_pass_fail, f, indent=2)

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -78,8 +78,6 @@ def command_line_options():
 
     args.passing_labels = get_passing_labels(args.num_passing_labels)
 
-    args.output_filename = 'report-pass-fail.html' if args.passing_labels else 'report-exact-match.html'
-
     if args.student_ids:
         args.student_ids = args.student_ids.split(',')
 
@@ -340,8 +338,7 @@ def main():
         rubric = standard_rubric
 
         # set up output and cache directories
-        output_file = os.path.join(experiment_lesson_prefix, output_dir_name, options.output_filename)
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+        os.makedirs(os.path.join(experiment_lesson_prefix, output_dir_name), exist_ok=True)
         os.makedirs(os.path.join(experiment_lesson_prefix, cache_dir_name), exist_ok=True)
         if not options.use_cached:
             for file in glob.glob(f'{os.path.join(experiment_lesson_prefix, cache_dir_name)}/*'):
@@ -354,6 +351,9 @@ def main():
         errors = [student_id for student_id, labels in predicted_labels if not labels]
         # predicted_labels contains metadata and data (labels), we care about the data key
         predicted_labels = {student_id: labels['data'] for student_id, labels in predicted_labels if labels}
+
+        output_filename = 'report-pass-fail.html' if options.passing_labels else 'report-exact-match.html'
+        output_file = os.path.join(experiment_lesson_prefix, output_dir_name, output_filename)
 
         # calculate accuracy and generate report
         accuracy_by_criteria, overall_accuracy, confusion_by_criteria, overall_confusion, label_names = compute_accuracy(actual_labels, predicted_labels, options.passing_labels)
@@ -390,7 +390,7 @@ def main():
         )
         logging.info(f"lesson {lesson} finished in {int(time.time() - main_start_time)} seconds")
 
-        if options.accuracy and accuracy_thresholds is not None:
+        if options.accuracy and accuracy_thresholds is not None and options.passing_labels is None:
             if overall_accuracy < accuracy_thresholds[lesson]['overall']:
                 accuracy_pass = False
                 accuracy_failures[lesson] = {}

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -409,17 +409,18 @@ def main():
         os.system(f"open {output_file}")
 
         if options.generate_confidence:
-            confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
-            with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
-                json.dump(confidence_pass_fail, f, indent=2)
-                f.write('\n')
-                logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence.json')}")
-
-            confidence_exact_match = get_exact_match_confidence(confusion_by_criteria)
-            with open(os.path.join(experiment_lesson_prefix, 'confidence-exact.json'), 'w') as f:
-                json.dump(confidence_exact_match, f, indent=2)
-                f.write('\n')
-                logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence-exact.json')}")
+            if options.passing_labels:
+                confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
+                with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
+                    json.dump(confidence_pass_fail, f, indent=2)
+                    f.write('\n')
+                    logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence.json')}")
+            else:
+                confidence_exact_match = get_exact_match_confidence(confusion_by_criteria)
+                with open(os.path.join(experiment_lesson_prefix, 'confidence-exact.json'), 'w') as f:
+                    json.dump(confidence_exact_match, f, indent=2)
+                    f.write('\n')
+                    logging.info(f"writing {os.path.join(experiment_lesson_prefix, 'confidence-exact.json')}")
 
     if not accuracy_pass and len(accuracy_failures.keys()) > 0:
         logging.error(f"The following thresholds were not met:\n{pp.pformat(accuracy_failures)}")

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 from lib.assessment.config import SUPPORTED_MODELS, DEFAULT_MODEL, VALID_LABELS, LESSONS, DEFAULT_DATASET_NAME, DEFAULT_EXPERIMENT_NAME
 from lib.assessment.label import Label, InvalidResponseError, RequestTooLargeError
 from lib.assessment.report import Report
-from lib.assessment.confidence import get_pass_fail_confidence
+from lib.assessment.confidence import get_pass_fail_confidence, get_exact_match_confidence
 
 #globals
 prompt_file = 'system_prompt.txt'
@@ -416,6 +416,11 @@ def main():
         confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
         with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
             json.dump(confidence_pass_fail, f, indent=4)
+            f.write('\n')
+
+        confidence_exact_match = get_exact_match_confidence(confusion_by_criteria)
+        with open(os.path.join(experiment_lesson_prefix, 'confidence-exact.json'), 'w') as f:
+            json.dump(confidence_exact_match, f, indent=4)
             f.write('\n')
 
     return accuracy_pass

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -416,6 +416,7 @@ def main():
         confidence_pass_fail = get_pass_fail_confidence(accuracy_by_criteria)
         with open(os.path.join(experiment_lesson_prefix, 'confidence.json'), 'w') as f:
             json.dump(confidence_pass_fail, f, indent=4)
+            f.write('\n')
 
     return accuracy_pass
 

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -196,7 +196,7 @@ def validate_students(student_files, actual_labels):
         raise Exception(f"unexpected students: {unexpected_students}")
 
 
-def compute_accuracy(actual_labels, predicted_labels, passing_labels):
+def compute_accuracy(actual_labels, predicted_labels, is_pass_fail):
     actual_by_criteria = defaultdict(list)
     predicted_by_criteria = defaultdict(list)
     confusion_by_criteria = {}
@@ -213,12 +213,12 @@ def compute_accuracy(actual_labels, predicted_labels, passing_labels):
     accuracy_by_criteria = {}
 
     for criteria in predicted_by_criteria.keys():
-        if (passing_labels):
-            pass_string = "/".join(passing_labels)
-            fail_string = "/".join([label for label in VALID_LABELS if label not in passing_labels])
+        if (is_pass_fail):
+            pass_string = "/".join(PASSING_LABELS)
+            fail_string = "/".join([label for label in VALID_LABELS if label not in PASSING_LABELS])
             label_names = [pass_string, fail_string]
-            predicted_by_criteria[criteria] = list(map(lambda x: pass_string if x in passing_labels else fail_string, predicted_by_criteria[criteria]))
-            actual_by_criteria[criteria] = list(map(lambda x: pass_string if x in passing_labels else fail_string, actual_by_criteria[criteria]))
+            predicted_by_criteria[criteria] = list(map(lambda x: pass_string if x in PASSING_LABELS else fail_string, predicted_by_criteria[criteria]))
+            actual_by_criteria[criteria] = list(map(lambda x: pass_string if x in PASSING_LABELS else fail_string, actual_by_criteria[criteria]))
         
         predicted = predicted_by_criteria[criteria]
         actual = actual_by_criteria[criteria]
@@ -341,13 +341,11 @@ def main():
         predicted_labels = {student_id: labels['data'] for student_id, labels in predicted_labels if labels}
 
         for is_pass_fail in [True, False]:
-            passing_labels = PASSING_LABELS if is_pass_fail else None
-
             output_filename = 'report-pass-fail.html' if is_pass_fail else 'report-exact-match.html'
             output_file = os.path.join(experiment_lesson_prefix, output_dir_name, output_filename)
 
             # calculate accuracy and generate report
-            accuracy_by_criteria, overall_accuracy, confusion_by_criteria, overall_confusion, label_names = compute_accuracy(actual_labels, predicted_labels, passing_labels)
+            accuracy_by_criteria, overall_accuracy, confusion_by_criteria, overall_confusion, label_names = compute_accuracy(actual_labels, predicted_labels, is_pass_fail)
             overall_accuracy_percent = overall_accuracy * 100
             accuracy_by_criteria_percent = {k:v*100 for k,v in accuracy_by_criteria.items()}
             input_params = {
@@ -370,7 +368,7 @@ def main():
                 accuracy=overall_accuracy_percent,
                 predicted_labels=predicted_labels,
                 actual_labels=actual_labels,
-                passing_labels=passing_labels,
+                is_pass_fail=is_pass_fail,
                 accuracy_by_criteria=accuracy_by_criteria_percent,
                 errors=errors,
                 input_params=input_params,

--- a/tests/unit/assessment/test_confidence.py
+++ b/tests/unit/assessment/test_confidence.py
@@ -1,10 +1,11 @@
 import json
 import unittest
+import numpy as np
+
+from lib.assessment.confidence import get_pass_fail_confidence, get_exact_match_confidence, get_predicted_class_stats
 
 class TestConfidence(unittest.TestCase):
     def test_pass_fail_confidence(self):
-        from lib.assessment.confidence import get_pass_fail_confidence
-
         learning_goal_accuracies = {
             "goal1": 0.9,
             "goal2": 0.8,
@@ -20,9 +21,6 @@ class TestConfidence(unittest.TestCase):
         assert get_pass_fail_confidence(learning_goal_accuracies) == expected
 
     def test_predicted_class_stats(self):
-        from lib.assessment.confidence import get_predicted_class_stats
-        import numpy as np
-
         confusion = np.array(
             [[4, 1, 0, 0],
              [5, 1, 0, 0],
@@ -41,9 +39,6 @@ class TestConfidence(unittest.TestCase):
             self.assertAlmostEqual(accuracies[i], expected_accuracies[i], 1e-4)
 
     def test_exact_match_confidence(self):
-        from lib.assessment.confidence import get_exact_match_confidence
-        import numpy as np
-
         confusion1 = np.array(
             [[17, 1, 1, 0],
              [1, 9, 1, 1],

--- a/tests/unit/assessment/test_confidence.py
+++ b/tests/unit/assessment/test_confidence.py
@@ -1,0 +1,19 @@
+import json
+
+class TestConfidence:
+    def test_pass_fail_confidence(self):
+        from lib.assessment.confidence import get_pass_fail_confidence
+
+        learning_goal_accuracies = {
+            "goal1": 0.9,
+            "goal2": 0.8,
+            "goal3": 0.7
+        }
+
+        expected = {
+            "goal1": "HIGH",
+            "goal2": "MEDIUM",
+            "goal3": "LOW"
+        }
+
+        assert get_pass_fail_confidence(learning_goal_accuracies) == expected

--- a/tests/unit/assessment/test_confidence.py
+++ b/tests/unit/assessment/test_confidence.py
@@ -1,6 +1,7 @@
 import json
+import unittest
 
-class TestConfidence:
+class TestConfidence(unittest.TestCase):
     def test_pass_fail_confidence(self):
         from lib.assessment.confidence import get_pass_fail_confidence
 
@@ -17,3 +18,63 @@ class TestConfidence:
         }
 
         assert get_pass_fail_confidence(learning_goal_accuracies) == expected
+
+    def test_predicted_class_stats(self):
+        from lib.assessment.confidence import get_predicted_class_stats
+        import numpy as np
+
+        confusion = np.array(
+            [[4, 1, 0, 0],
+             [5, 1, 0, 0],
+             [0, 0, 8, 0],
+             [0, 0, 0, 0]]
+        )
+
+        expected_counts = [9, 2, 8, 0]
+        expected_accuracies = [4/9, 1/2, 8/8, 0]
+
+        counts, accuracies = get_predicted_class_stats(confusion)
+
+        assert counts == expected_counts
+
+        for i in range(len(accuracies)):
+            self.assertAlmostEqual(accuracies[i], expected_accuracies[i], 1e-4)
+
+    def test_exact_match_confidence(self):
+        from lib.assessment.confidence import get_exact_match_confidence
+        import numpy as np
+
+        confusion1 = np.array(
+            [[17, 1, 1, 0],
+             [1, 9, 1, 1],
+             [1, 0, 15, 1],
+             [0, 0, 0, 14]]
+        )
+        confusion2 = np.array(
+            [[5, 1, 0, 0],
+             [5, 1, 0, 0],
+             [0, 0, 8, 0],
+             [0, 0, 0, 0]]
+        )
+
+        confusion_by_criteria = {
+            "goal1": confusion1,
+            "goal2": confusion2
+        }
+
+        expected = {
+            "goal1": {
+                "Extensive Evidence": "HIGH",   # 17 / 19 = 0.8947
+                "Convincing Evidence": "HIGH",  #  9 / 10 = 0.9
+                "Limited Evidence": "HIGH",     # 15 / 17 = 0.8823
+                "No Evidence": "LOW"            # 14 / 16 = 0.875
+            },
+            "goal2": {
+                "Extensive Evidence": "LOW",
+                "Convincing Evidence": "LOW",
+                "Limited Evidence": "LOW",
+                "No Evidence": "LOW"
+            }
+        }
+
+        assert get_exact_match_confidence(confusion_by_criteria) == expected

--- a/tests/unit/assessment/test_report.py
+++ b/tests/unit/assessment/test_report.py
@@ -15,26 +15,20 @@ def report():
 
 
 class TestAccurate:
-    def test_should_just_match_actual_to_predicted_if_no_passing_labels(self):
-        assert Report.accurate('No Evidence', 'No Evidence', None)
-
-    def test_should_return_false_when_actual_is_not_predicted_if_no_passing_labels(self):
-        assert Report.accurate('No Evidence', 'Limited Evidence', None) == False
-
     def test_should_count_equal_number_of_matching_labels_in_given_passing_labels(self):
-        assert Report.accurate('Convincing Evidence', 'Convincing Evidence', ['Convincing Evidence', 'Extensive Evidence'])
+        assert Report.accurate_pass_fail('Convincing Evidence', 'Convincing Evidence')
 
     def test_should_be_true_when_actual_not_matching_predicted_but_both_in_given_passing_labels(self):
-        assert Report.accurate('Convincing Evidence', 'Extensive Evidence', ['Convincing Evidence', 'Extensive Evidence'])
+        assert Report.accurate_pass_fail('Convincing Evidence', 'Extensive Evidence')
 
     def test_should_return_true_when_neither_are_in_set_of_passing_labels(self):
-        assert Report.accurate('No Evidence', 'Limited Evidence', ['Convincing Evidence', 'Extensive Evidence'])
+        assert Report.accurate_pass_fail('No Evidence', 'Limited Evidence')
 
     def test_should_return_false_when_actual_is_not_in_set_of_passing_labels(self):
-        assert Report.accurate('No Evidence', 'Convincing Evidence', ['Convincing Evidence', 'Extensive Evidence']) == False
+        assert Report.accurate_pass_fail('No Evidence', 'Convincing Evidence') == False
 
     def test_should_return_false_when_predicted_is_not_in_set_of_passing_labels(self):
-        assert Report.accurate('Convincing Evidence', 'No Evidence', ['Convincing Evidence', 'Extensive Evidence']) == False
+        assert Report.accurate_pass_fail('Convincing Evidence', 'No Evidence') == False
 
 
 class TestGenerateHtmlOutput:
@@ -284,14 +278,13 @@ class TestGenerateHtmlOutput:
                 actual_labels[student_id] = actual_labels.get(student_id, {})
                 actual_labels[student_id][key_concept] = random_label_generator()
 
-        passing_labels = ['Extensive Evidence', 'Convincing Evidence']
         report.generate_html_output(
             output_file,
             prompt,
             rubric,
             predicted_labels=predicted_labels,
             actual_labels=actual_labels,
-            passing_labels=passing_labels,
+            is_pass_fail=True,
             input_params={'lesson_name': 'my-lesson'},
         )
 
@@ -332,4 +325,3 @@ class TestGenerateHtmlOutput:
         # Find all of the random strings we used as errored student ids
         for error in errors:
             assert error in output
-            

--- a/tests/unit/assessment/test_rubric_tester.py
+++ b/tests/unit/assessment/test_rubric_tester.py
@@ -57,19 +57,6 @@ class TestReadAndLabelStudentWork:
         assert result[1] == labels
 
 
-class TestGetPassingLabels:
-    def test_should_return_all_values_when_input_would_indicate_all_values(self):
-        assert len(get_passing_labels(4)) == 4
-        assert get_passing_labels(4).sort() == ['Extensive Evidence', 'Convincing Evidence', 'Limited Evidence', 'No Evidence'].sort()
-
-    def test_should_simply_return_top_values(self):
-        assert len(get_passing_labels(2)) == 2
-        assert get_passing_labels(2).sort() == ['Extensive Evidence', 'Convincing Evidence'].sort()
-
-    def test_should_return_none_if_the_number_of_passing_labels_is_none(self):
-        assert get_passing_labels(0) is None
-
-
 class TestReadInputs:
     def test_should_read_prompt_and_rubric_file(self, mocker, randomstring, prompt, rubric):
         prompt_file = randomstring(10) + '.txt'

--- a/tests/unit/assessment/test_rubric_tester.py
+++ b/tests/unit/assessment/test_rubric_tester.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 
 from lib.assessment.rubric_tester import (
     read_and_label_student_work,
-    get_passing_labels,
     read_inputs,
     get_student_files,
     get_actual_labels,


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-585, using these [Accuracy Thresholds](https://docs.google.com/document/d/1OCtVDskN0z4-_vYBgt3Bv7P9xB6IlIn5b3mEEeCR0nY/edit#heading=h.wcay8rlo68tu) . 

This PR introduces the `--generate-confidence` or `-g` flag to make rubric tester automatically generate confidence.json and confidence-exact.json files. note that rubric tester needs to be run twice, with and without pass/fail mode (`-p 2`), in order to generate both files:

```
(.venv) Dave-MBP:~/src/aiproxy (generate-confidence-json)$ python ./lib/assessment/rubric_tester.py -e 2024-04-26-confidence-autogen --dataset-name contractor-grades-abridged -c -g

2024-04-26 09:59:57,801: INFO: Evaluating lesson csd3-2023-L11 for dataset contractor-grades-abridged and experiment 2024-04-26-confidence-autogen...
2024-04-26 09:59:57,817: INFO: lesson csd3-2023-L11 finished in 0 seconds
2024-04-26 09:59:57,954: INFO: writing experiments/2024-04-26-confidence-autogen/csd3-2023-L11/confidence-exact.json
2024-04-26 09:59:57,955: INFO: Evaluating lesson csd3-2023-L14 for dataset contractor-grades-abridged and experiment 2024-04-26-confidence-autogen...
...
```

```
(.venv) Dave-MBP:~/src/aiproxy (generate-confidence-json)$ python ./lib/assessment/rubric_tester.py -e 2024-04-26-confidence-autogen --dataset-name contractor-grades-abridged -c -g -p 2

2024-04-26 10:00:29,054: INFO: Evaluating lesson csd3-2023-L11 for dataset contractor-grades-abridged and experiment 2024-04-26-confidence-autogen...
2024-04-26 10:00:29,074: INFO: lesson csd3-2023-L11 finished in 0 seconds
2024-04-26 10:00:29,224: INFO: writing experiments/2024-04-26-confidence-autogen/csd3-2023-L11/confidence.json
...
```

## Testing story

* new unit tests
* manually verified that the output in the `confidence*.json` files looks correct based on what you see in the `report*.html` files (see screenshots below)
* also see a diff of what changes appear in the new release at https://github.com/code-dot-org/code-dot-org/pull/58282

## screenshots

I manually verified that each confidence level is being generated correctly based on the output in the corresponding report file. 

### pass / fail

for each lesson, I compared `confidence.json` vs `output/report-pass-fail.html`. since this was pretty straight forward I am only including a couple of examples to show here:

Lesson 24 shows medium confidence below 85%:
![Screenshot 2024-04-26 at 11 08 42 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/49aadb91-bd9f-4d8d-a8d5-618e5bfd6436)

Lesson 28 shows low confidence below 80%:
![Screenshot 2024-04-26 at 11 09 13 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/2c76fdb7-9476-40bb-9b7b-d2b1506fc7ca)

### exact match

for each lesson, I compared `confidence-exact.json` vs `output/report-exact-match.html`.

#### Lesson 11
![Screenshot 2024-04-26 at 11 17 20 AM](https://github.com/code-dot-org/code-dot-org/assets/8001765/fb6fef8b-fee1-45c2-b4a0-c16b4bbd5ffd)

#### Lesson 14
![Screenshot 2024-04-26 at 11 21 42 AM](https://github.com/code-dot-org/aiproxy/assets/8001765/251ffa79-4bcd-4159-86c0-a8a1ee6526b9)

#### Lesson 18
![Screenshot 2024-04-26 at 11 26 10 AM](https://github.com/code-dot-org/aiproxy/assets/8001765/c19a59fd-0002-44b6-aebf-ada856afa58f)

### Lesson 21
![Screenshot 2024-04-26 at 11 28 05 AM](https://github.com/code-dot-org/aiproxy/assets/8001765/254d8f14-63f7-455f-860c-d6af381fac99)

#### Lesson 24
![Screenshot 2024-04-26 at 11 28 39 AM](https://github.com/code-dot-org/aiproxy/assets/8001765/2b0b47bf-b9a2-4784-99cc-0f5007629299)

#### Lesson 28 
![Screenshot 2024-04-26 at 11 30 22 AM](https://github.com/code-dot-org/aiproxy/assets/8001765/93246dbd-d422-4ede-a814-58cc1ae46796)
