### PR TITLE
Recover when request is too large for LLM context window

### DIFF
--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -188,6 +188,7 @@ class Label:
 
         if self._openai_context_length_exceeded(response):
             message = response.json().get('error', {}).get('message')
+            logging.error(f"{student_id} Request too large: {message}")
             raise RequestTooLargeError(f"{student_id} {message}")
         elif response.status_code != 200:
             logging.error(f"{student_id} Error calling the API: {response.status_code}")

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -370,6 +370,10 @@ class Label:
             if reraise:
                 raise e
             return None
+        except RequestTooLargeError as e:
+            logging.error(f"{student_id} {choice_text} Request too large: {str(e)}")
+            if reraise:
+                raise e
 
     # gpt-4-0613 has a context window of 8192 tokens, which is the limit for input + output tokens.
     # If the json in the response is unparseable, and the llm says the response was truncated due to length,

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -366,12 +366,12 @@ class Label:
             self._validate_server_response(response_data, rubric)
             return [row for row in response_data]
         except InvalidResponseError as e:
-            logging.error(f"{student_id} {choice_text} Invalid response: {str(e)}\n{response_text}")
+            logging.info(f"{student_id} {choice_text} Invalid response: {str(e)}\n{response_text}")
             if reraise:
                 raise e
             return None
         except RequestTooLargeError as e:
-            logging.error(f"{student_id} {choice_text} Request too large: {str(e)}")
+            logging.info(f"{student_id} {choice_text} Request too large: {str(e)}")
             if reraise:
                 raise e
 

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -305,7 +305,7 @@ class Label:
             reraise = len(response_data_choices) == 0 and index == max_index
 
             if choice['message']['content']:
-                response_data = self.get_response_data_if_valid(choice['message']['content'], rubric, student_id, choice_index=index, reraise=reraise, response_type=response_type)
+                response_data = self.get_response_data_if_valid(choice, rubric, student_id, choice_index=index, reraise=reraise, response_type=response_type)
                 if response_data:
                     response_data_choices.append(response_data)
 
@@ -341,7 +341,8 @@ class Label:
         messages.append({'role': 'user', 'content': student_code})
         return messages
 
-    def get_response_data_if_valid(self, response_text, rubric, student_id, choice_index=None, reraise=False, response_type='tsv'):
+    def get_response_data_if_valid(self, choice, rubric, student_id, choice_index=None, reraise=False, response_type='tsv'):
+        response_text = choice['message']['content']
         try:
             choice_text = f"Choice {choice_index}: " if choice_index is not None else ''
             if not response_text:

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -345,8 +345,7 @@ class Label:
         try:
             choice_text = f"Choice {choice_index}: " if choice_index is not None else ''
             if not response_text:
-                logging.error(f"{student_id} {choice_text} Invalid response: empty response")
-                return None
+                raise InvalidResponseError("empty response")
             text = response_text.strip()
 
             if response_type == 'json':
@@ -369,15 +368,13 @@ class Label:
         # capture all data from the first '[' to the last ']', inclusive
         match = re.search(r'(\[.*\])', response_text,re.DOTALL)
         if not match:
-            logging.error(f"{student_id} Invalid response: no valid JSON data:\n{response_text}")
-            return None
+            raise InvalidResponseError(f"no valid JSON data:\n{response_text}")
         json_text = match.group(1)
 
         try:
             data = json.loads(json_text)
         except json.JSONDecodeError as e:
-            logging.error(f"{student_id} JSON decoding error: {e}\n{json_text}")
-            return None
+            raise InvalidResponseError(f"JSON decoding error: {e}\n{json_text}")
 
         return data
 

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -371,6 +371,10 @@ class Label:
                 raise e
             return None
 
+    # gpt-4-0613 has a context window of 8192 tokens, which is the limit for input + output tokens.
+    # If the json in the response is unparseable, and the llm says the response was truncated due to length,
+    # then assume the reason for the error is because the input was too large to leave enough remaining tokens
+    # for a valid response.
     def parse_json_response(self, response_text, student_id, finish_reason):
         # capture all data from the first '[' to the last ']', inclusive
         match = re.search(r'(\[.*\])', response_text,re.DOTALL)

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -342,20 +342,20 @@ class Label:
         return messages
 
     def get_response_data_if_valid(self, response_text, rubric, student_id, choice_index=None, reraise=False, response_type='tsv'):
-        choice_text = f"Choice {choice_index}: " if choice_index is not None else ''
-        if not response_text:
-            logging.error(f"{student_id} {choice_text} Invalid response: empty response")
-            return None
-        text = response_text.strip()
-
-        if response_type == 'json':
-            response_data = self.parse_json_response(text, student_id)
-        elif response_type == 'tsv':
-            response_data = self.parse_non_json_response(text)
-        else:
-            raise ValueError(f"Invalid response type: {response_type}")
-
         try:
+            choice_text = f"Choice {choice_index}: " if choice_index is not None else ''
+            if not response_text:
+                logging.error(f"{student_id} {choice_text} Invalid response: empty response")
+                return None
+            text = response_text.strip()
+
+            if response_type == 'json':
+                response_data = self.parse_json_response(text, student_id)
+            elif response_type == 'tsv':
+                response_data = self.parse_non_json_response(text)
+            else:
+                raise ValueError(f"Invalid response type: {response_type}")
+
             self._sanitize_server_response(response_data)
             self._validate_server_response(response_data, rubric)
             return [row for row in response_data]

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -21,7 +21,7 @@ from sklearn.metrics import accuracy_score, confusion_matrix
 from collections import defaultdict
 
 from lib.assessment.config import SUPPORTED_MODELS, DEFAULT_MODEL, VALID_LABELS, LESSONS, DEFAULT_DATASET_NAME, DEFAULT_EXPERIMENT_NAME
-from lib.assessment.label import Label, InvalidResponseError
+from lib.assessment.label import Label, InvalidResponseError, RequestTooLargeError
 from lib.assessment.report import Report
 
 #globals
@@ -267,6 +267,9 @@ def read_and_label_student_work(prompt, rubric, student_file, examples, options,
             cache_prefix=prefix
         )
     except InvalidResponseError as e:
+        # these error details have already been logged
+        labels = None
+    except RequestTooLargeError as e:
         # these error details have already been logged
         labels = None
     except Exception as e:

--- a/src/assessment.py
+++ b/src/assessment.py
@@ -13,7 +13,7 @@ from lib.assessment.config import DEFAULT_MODEL
 # Our assessment code
 from lib.assessment import assess
 from lib.assessment.assess import KeyConceptError
-from lib.assessment.label import InvalidResponseError
+from lib.assessment.label import InvalidResponseError, RequestTooLargeError
 
 assessment_routes = Blueprint('assessment_routes', __name__)
 
@@ -50,8 +50,8 @@ def post_assessment():
         )
     except ValueError:
         return "One of the arguments is not parseable as a number", 400
-    except openai.error.InvalidRequestError as e:
-        return str(e), 400
+    except RequestTooLargeError as e:
+        return str(e), 413
     except InvalidResponseError as e:
         return f'InvalidResponseError: {str(e)}', 400
     except KeyConceptError as e:

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -1,5 +1,6 @@
 import openai
 
+from lib.assessment.label import RequestTooLargeError
 
 class TestPostAssessment:
     """ Tests POST to '/assessment' to start an assessment.
@@ -44,8 +45,8 @@ class TestPostAssessment:
         })
         assert response.status_code == 400
 
-    def test_should_return_400_on_openai_error(self, mocker, client, randomstring):
-        mocker.patch('lib.assessment.assess.label').side_effect = openai.error.InvalidRequestError('', '')
+    def test_should_return_413_on_request_too_large_error(self, mocker, client, randomstring):
+        mocker.patch('lib.assessment.assess.label').side_effect = RequestTooLargeError('')
         response = client.post('/assessment', data={
           "code": randomstring(10),
           "prompt": randomstring(10),
@@ -57,7 +58,7 @@ class TestPostAssessment:
           "num-responses": "1",
           "temperature": "0.2",
         })
-        assert response.status_code == 400
+        assert response.status_code == 413
 
     def test_should_return_400_when_passing_not_a_number_to_num_responses(self, client, randomstring):
         response = client.post('/assessment', data={

--- a/tests/unit/assessment/conftest.py
+++ b/tests/unit/assessment/conftest.py
@@ -294,3 +294,19 @@ def openai_gpt_response(randomstring):
         return f"{data['Key Concept']}{delimiter}{data['Observations']}{delimiter}{data['Grade']}{delimiter}{data['Reason']}\n"
 
     return gen_gpt_response
+
+@pytest.fixture
+def openai_gpt_response_too_large():
+    """ Returns a GPT response indicating the model's context length was exceeded.
+    """
+
+    response_data = {
+        "error": {
+            "message": "This model's maximum context length is 8192 tokens. However, your messages resulted in 9145 tokens. Please reduce the length of the messages.",
+            "type": "invalid_request_error",
+            "param": "messages",
+            "code": "context_length_exceeded"
+        }
+    }
+    # return json.dumps(response_data)
+    return response_data

--- a/tests/unit/assessment/conftest.py
+++ b/tests/unit/assessment/conftest.py
@@ -296,13 +296,17 @@ def openai_gpt_response(randomstring):
     return gen_gpt_response
 
 @pytest.fixture
-def openai_gpt_response_too_large():
+def context_length_message():
+    return "This model's maximum context length is 8192 tokens. However, your messages resulted in 9145 tokens. Please reduce the length of the messages."
+
+@pytest.fixture
+def openai_response_too_large(context_length_message):
     """ Returns a GPT response indicating the model's context length was exceeded.
     """
 
     response_data = {
         "error": {
-            "message": "This model's maximum context length is 8192 tokens. However, your messages resulted in 9145 tokens. Please reduce the length of the messages.",
+            "message": context_length_message,
             "type": "invalid_request_error",
             "param": "messages",
             "code": "context_length_exceeded"

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -160,10 +160,11 @@ class TestGetResponseDataIfValid:
         assert result is None
 
     def test_should_log_the_choice_index_if_the_response_is_blank(self, caplog, label, rubric, student_id, choice):
+        caplog.set_level(logging.INFO)
         index = random.randint(0, 5)
         label.get_response_data_if_valid(choice, rubric, student_id, choice_index=index)
 
-        assert any(filter(lambda x: (f'Choice {index}' in x.message) and x.levelno == logging.ERROR, caplog.records))
+        assert any(filter(lambda x: (f'Choice {index}' in x.message) and x.levelno == logging.INFO, caplog.records))
 
     @pytest.mark.parametrize("output_type", ['tsv', 'csv', 'markdown'])
     def test_should_work_for_different_output_types(self, label, rubric, student_id, openai_gpt_response, output_type):

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -357,7 +357,7 @@ class TestGetResponseDataIfValid:
         choice['finish_reason'] = 'length' # response was truncated
 
         with pytest.raises(RequestTooLargeError) as error:
-            label.get_response_data_if_valid(choice, rubric, student_id, response_type='json')
+            label.get_response_data_if_valid(choice, rubric, student_id, reraise=True, response_type='json')
         assert "no valid JSON data" in str(error.value)
 
     def test_should_raise_invalid_response_when_untruncated_response_contains_no_json(self, mocker, label, rubric, student_id, openai_gpt_response):
@@ -377,7 +377,7 @@ class TestGetResponseDataIfValid:
         choice['finish_reason'] = 'length' # response was truncated
 
         with pytest.raises(RequestTooLargeError) as error:
-            label.get_response_data_if_valid(choice, rubric, student_id, response_type='json')
+            label.get_response_data_if_valid(choice, rubric, student_id, reraise=True, response_type='json')
         assert "JSON decoding error" in str(error.value)
 
     def test_should_raise_invalid_response_when_untruncated_json_is_unparsable(self, mocker, label, rubric, student_id, openai_gpt_response):

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -9,7 +9,7 @@ from io import StringIO
 import requests
 import pytest
 
-from lib.assessment.label import Label, InvalidResponseError
+from lib.assessment.label import Label, InvalidResponseError, RequestTooLargeError
 
 
 @pytest.fixture
@@ -378,7 +378,27 @@ class TestAiLabelStudentWork:
 
         # It should contain the concepts given in the rubric
         assert set(x['Key Concept'] for x in parsed_rubric) == set(x['Key Concept'] for x in result['data'])
-        
+
+    def test_should_raise_request_too_large_when_context_length_exceeded(
+            self, requests_mock, openai_gpt_response_too_large, label, prompt, rubric, code, student_id,
+            examples, num_responses, temperature, llm_model):
+
+        requests_mock.post(
+            'https://api.openai.com/v1/chat/completions',
+            json=openai_gpt_response_too_large,
+            headers={'Content-Type': 'application/json'},
+            status_code=400,
+        )
+
+        parsed_rubric = list(csv.DictReader(rubric.splitlines()))
+
+        with pytest.raises(RequestTooLargeError) as error:
+            label.ai_label_student_work(
+                prompt, rubric, code, student_id, examples(rubric), num_responses, temperature, llm_model
+            )
+        message = "This model's maximum context length is 8192 tokens. However, your messages resulted in 9145 tokens. Please reduce the length of the messages."
+        assert message in str(error.value)
+
     def test_should_return_data_as_none_when_ai_result_is_empty(self, requests_mock, mocker, openai_gpt_response, label, prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model):
         mock_gpt_response = openai_gpt_response(
             rubric=rubric,

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -380,12 +380,12 @@ class TestAiLabelStudentWork:
         assert set(x['Key Concept'] for x in parsed_rubric) == set(x['Key Concept'] for x in result['data'])
 
     def test_should_raise_request_too_large_when_context_length_exceeded(
-            self, requests_mock, openai_gpt_response_too_large, label, prompt, rubric, code, student_id,
-            examples, num_responses, temperature, llm_model):
+            self, requests_mock, openai_response_too_large, label, prompt, rubric, code, student_id,
+            examples, num_responses, temperature, llm_model, context_length_message):
 
         requests_mock.post(
             'https://api.openai.com/v1/chat/completions',
-            json=openai_gpt_response_too_large,
+            json=openai_response_too_large,
             headers={'Content-Type': 'application/json'},
             status_code=400,
         )
@@ -396,8 +396,7 @@ class TestAiLabelStudentWork:
             label.ai_label_student_work(
                 prompt, rubric, code, student_id, examples(rubric), num_responses, temperature, llm_model
             )
-        message = "This model's maximum context length is 8192 tokens. However, your messages resulted in 9145 tokens. Please reduce the length of the messages."
-        assert message in str(error.value)
+        assert context_length_message in str(error.value)
 
     def test_should_return_data_as_none_when_ai_result_is_empty(self, requests_mock, mocker, openai_gpt_response, label, prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model):
         mock_gpt_response = openai_gpt_response(


### PR DESCRIPTION
Addresses the issue affecting the pilot where we show a vague error to the teacher when ai fails to evaluate student code specifically because the code is too long: https://codedotorg.slack.com/archives/C051P2V2RN0/p1713375040112099

## background

* The GPT 4 context window size is 8K tokens. input tokens (system prompt + rubric + student code)  + output tokens must be less than this amount.
* if input tokens exceed 8K, openai immediately returns `400 Bad Request` with code `context_length_exceeded`
*  if input < 8K and input + output > 8K, openai will return `200 OK` but will truncate the response, and give `finish_reason: 'length'`. this truncation usually results in unparseable JSON.

## proposal (this PR)

solve the 95-98% case by returning a helpful error message when the student code is too large. Then, come back and solve the issue for large code samples by switching to a model with a larger context window.

## alternatives considered

* there is no value in setting a max_length parameter -- openai already implicitly sets this limit to 8K - input size.
* we could possibly solve this problem by switching to GPT 4 Turbo (128K, cheaper) or GPT 4 32K ($$$$). however, we decided that either of these approaches would be too time consuming to verify quickly, and could leave us in a pinch if we needed to roll that change back for any reason.
* why not detect code that's too long earlier? because there's no way to get accurate token counts without making a separate API call, and doing this on every request seems like more trouble than it's worth for an edge case.

shoutout to @cearachew for being a great design partner in making sure we avoided any of the less desirable alternatives 😅 

## Done in this PR

1. make flask return http status code 413 Content Too Large in the following cases:
    a. openai returns 400 due to context_length_exceeded (input alone exceeds context window)
    b. response cannot be parsed as json AND response metadata indicates response body was truncated due to length
2. bonus: return successful response as long as at least one of the n=3 response choices can be parsed as json. this was previously implemented for InvalidResponseError, but did not work for other error cases.

## output

here is how it looks in rubric tester:
```
(.venv) Dave-MBP:~/src/aiproxy (recover-from-request-too-large)$ python ./lib/assessment/rubric_tester.py -e 2024-03-25-confidence-exact --student-ids student_55,student_60 --lesson-names csd3-2023-L28

2024-04-19 12:40:07,109: INFO: Evaluating lesson csd3-2023-L28 for dataset contractor-grades-batch-1-fall-2023 and experiment 2024-03-25-confidence-exact...
2024-04-19 12:41:25,629: INFO: student_60 Choice 0:  Request too large: student_60: no valid JSON data
2024-04-19 12:41:25,629: INFO: student_60 Choice 1:  Request too large: student_60: no valid JSON data
2024-04-19 12:41:25,629: INFO: student_60 Choice 2:  Request too large: student_60: no valid JSON data
2024-04-19 12:41:25,629: ERROR: Error in labeling student student_60: student_60: no valid JSON data
2024-04-19 12:41:57,376: INFO: student_55 request succeeded in 110 seconds. 10248 tokens used.
2024-04-19 12:41:57,385: INFO: lesson csd3-2023-L28 finished in 110 seconds
```
with slightly more code for student_55:
```
(.venv) Dave-MBP:~/src/aiproxy (recover-from-request-too-large)$ python ./lib/assessment/rubric_tester.py -e 2024-03-25-confidence-exact --dataset-name contractor-grades-large --student-ids student_55 --lesson-names csd3-2023-L28
2024-04-19 12:57:23,464: INFO: Evaluating lesson csd3-2023-L28 for dataset contractor-grades-large and experiment 2024-03-25-confidence-exact...
2024-04-19 12:59:17,877: INFO: student_55 Choice 1:  Request too large: student_55: no valid JSON data
2024-04-19 12:59:17,877: INFO: student_55 Choice 2:  Request too large: student_55: no valid JSON data
2024-04-19 12:59:17,878: INFO: student_55 request succeeded in 114 seconds. 10796 tokens used.
2024-04-19 12:59:17,895: INFO: lesson csd3-2023-L28 finished in 114 seconds
```

## screenshot

when a teacher requests ai eval for student code that's too long, active job receives a 413 from aiproxy:
![Screenshot 2024-04-19 at 1 21 34 PM](https://github.com/code-dot-org/aiproxy/assets/8001765/30adfd6f-2e69-486b-8bcd-98a223b9c7b4)


## Testing story

* new unit tests
* manual testing in rubric tester (output above)
* manual integration testing (screenshots above)

## Follow-up work

* make dashboard show a sensible error message to the teacher in response to the 413
* prioritize the switch to GPT 4 Turbo, which should eliminate errors related to size limits due to the much larger context window.