### PR TITLE
CFE for Lesson 24 modularity

### DIFF
--- a/lib/assessment/decision_trees.py
+++ b/lib/assessment/decision_trees.py
@@ -105,6 +105,7 @@ class DecisionTrees:
   def u3l18_modularity_assessment(self, data):
     sprites = data["object_types"]["sprites"]
 
+    # set of sprites that have a property set inside the drawloop (including calling setAnimation)
     sprites_updated_in_draw = set([property["object"] for property in data["property_change"] if
                                    any([obj["identifier"] == property["object"] and
                                         obj["type"]=="sprite" for obj in data["objects"]])
@@ -120,6 +121,42 @@ class DecisionTrees:
 
     # Limited Evidence: At least 2 sprites
     elif sprites >= 1:
+      return "Limited Evidence"
+
+    # No Evidence: No sprites
+    return "No Evidence"
+  
+  def u3l24_modularity_assessment(self, data):
+    sprites = data["object_types"]["sprites"]
+
+    # set of sprites that have their animation set outside the drawloop
+    animation_set = set([property["object"] for property in data["property_change"] if
+                                   any([obj["identifier"] == property["object"] and
+                                        obj["type"]=="sprite" for obj in data["objects"]])
+                                  and property["draw_loop"] == False
+                                  and "method" in property.keys()
+                                  and property["method"] == "setAnimation"
+                                  ])
+    
+    # set of sprites that have velocity set outside the drawloop
+    velocity_set = set([property["object"] for property in data["property_change"] if
+                                   any([obj["identifier"] == property["object"] and
+                                        obj["type"]=="sprite" for obj in data["objects"]])
+                                  and property["draw_loop"] == False
+                                  and "property" in property.keys()
+                                  and "velocity" in property["property"]
+                                  ])
+
+    # Extensive Evidence: At least 3 sprites, at least 3 of them have properties updated in the draw loop
+    if sprites >= 4 and len(animation_set) >= 4 and len(velocity_set) >= 2:
+      return "Extensive Evidence"
+
+    # Convincing Evidence: At least 1 sprites, at least 1 of them have properties updated in the draw loop
+    elif sprites >= 3 and len(animation_set) >= 3 and len(velocity_set) >= 1:
+      return "Convincing Evidence"
+
+    # Limited Evidence: At least 2 sprites
+    elif sprites >= 2 and len(animation_set) >= 2:
       return "Limited Evidence"
 
     # No Evidence: No sprites

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -68,7 +68,6 @@ class Label:
         # to output dictionary
         for learning_goal in learning_goals:
             # Create instance of feature extractor
-            print(f"{learning_goal}, {lesson}")
             cfe = CodeFeatures()
             cfe.extract_features(student_code, learning_goal, lesson)
             results["data"].append({"Label": cfe.assessment,

--- a/tests/unit/assessment/test_code_feature_extractor.py
+++ b/tests/unit/assessment/test_code_feature_extractor.py
@@ -2,6 +2,9 @@ import pytest
 from lib.assessment.code_feature_extractor import CodeFeatures
 import esprima
 
+import pprint
+pp = pprint.PrettyPrinter(indent=2)
+
 @pytest.fixture
 def code_features():
     """ Creates a Label() instance for any test that has a 'label' parameter.
@@ -202,6 +205,99 @@ function draw() {
                                'object': 'fremen',
                                'start': 12}]
     assert code_features.assessment == 'Extensive Evidence'
+
+  def test_u3l24_modularity_feature_extractor(self, code_features):
+    learning_goal = {"Key Concept": "Modularity - Multiple Sprites"
+                     }
+    code = """var shai_hulud = createSprite(100, 275);
+var muadib = createSprite(50, 100);
+muadib.setAnimation("muadib");
+var fremen = createSprite(0, 275);
+fremen.setAnimation("fremen");
+fremen.velocityY = 1;
+shai_hulud.setAnimation("worm");
+shai_hulud.velocityX = 2;
+function draw() {
+    rhythm = randomNumber(1, 100);
+    muadib.x = muadib.x + 2;
+    if (rhythm < 50){
+        shai_hulud.visible = False;
+      }
+    if (muadib.x == shai_hulud.x && rhythm > 50) {
+        muadib.setAnimation("eyes of ibad");
+        fremen.setAnimation("lisan al gaib");
+    }
+}
+"""
+
+    lesson="csd3-2023-L24"
+
+    code_features.extract_features(code, learning_goal, lesson)
+
+    assert code_features.features["object_types"] == {'shapes': 0, 'sprites': 3, 'text': 0}
+    assert code_features.features["movement"] == {'random': 0, 'counter': 0}
+    assert code_features.features["objects"] == [ { 'end': 1,
+                              'identifier': 'shai_hulud',
+                              'properties': {'x': [100], 'y': [275]},
+                              'start': 1,
+                              'type': 'sprite'},
+                            { 'end': 2,
+                              'identifier': 'muadib',
+                              'properties': {'x': [50], 'y': [100]},
+                              'start': 2,
+                              'type': 'sprite'},
+                            { 'end': 4,
+                              'identifier': 'fremen',
+                              'properties': {'x': [0], 'y': [275]},
+                              'start': 4,
+                              'type': 'sprite'}]
+    assert code_features.features["property_change"] == [ { 'draw_loop': False,
+                              'end': 3,
+                              'method': 'setAnimation',
+                              'object': 'muadib',
+                              'start': 3},
+                            { 'draw_loop': False,
+                              'end': 5,
+                              'method': 'setAnimation',
+                              'object': 'fremen',
+                              'start': 5},
+                            { 'draw_loop': False,
+                              'end': 6,
+                              'object': 'fremen',
+                              'property': 'velocityY',
+                              'start': 6},
+                            { 'draw_loop': False,
+                              'end': 7,
+                              'method': 'setAnimation',
+                              'object': 'shai_hulud',
+                              'start': 7},
+                            { 'draw_loop': False,
+                              'end': 8,
+                              'object': 'shai_hulud',
+                              'property': 'velocityX',
+                              'start': 8},
+                            { 'draw_loop': True,
+                              'end': 11,
+                              'object': 'muadib',
+                              'property': 'x',
+                              'start': 11},
+                            { 'draw_loop': True,
+                              'end': 13,
+                              'object': 'shai_hulud',
+                              'property': 'visible',
+                              'start': 13},
+                            { 'draw_loop': True,
+                              'end': 16,
+                              'method': 'setAnimation',
+                              'object': 'muadib',
+                              'start': 16},
+                            { 'draw_loop': True,
+                              'end': 17,
+                              'method': 'setAnimation',
+                              'object': 'fremen',
+                              'start': 17}]
+    assert code_features.assessment == 'Convincing Evidence'
+
 
   def test_binary_expression_helper(self, code_features):
     statement = "x = x + 1"


### PR DESCRIPTION
Adds a decision tree and tests for lesson 24 modularity. 
Jira ticket: https://codedotorg.atlassian.net/browse/AITT-589

## Code Feature Extractor

 - Add lesson 24 modularity delegate functions
 - Fix logging formatting to avoid errors
 - Fix a no value assignment error

## Decision Tree

- Add decision tree that uses number of sprites created, number of sprites with velocity set outside the drawloop, and number of sprites with animations set outside the drawloop

## Testing 

- Add a unit test for Lesson 24 modularity
- Tested the CFE supported feature on the lesson 24 data, only 1 student sample is different from the actual value, but after looking into it, the human label was incorrect. 

<img width="612" alt="Screenshot 2024-04-22 at 4 07 19 PM" src="https://github.com/code-dot-org/aiproxy/assets/7144482/d8dd8a25-ba6a-46e3-bdd6-5d2c6aaad713">

<img width="736" alt="Screenshot 2024-04-22 at 4 08 03 PM" src="https://github.com/code-dot-org/aiproxy/assets/7144482/95b0a7e3-b308-449c-a3e0-ecdd14511430">

## Follow-up

This needs a follow-up to add the cfe features to the params file for lesson 24 in the next release, once evidence from CFE labels is merged
