### PR TITLE
add gpt-4-turbo-2024-04-09 model to aiproxy and rubric tester

### DIFF
--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -13,7 +13,8 @@ SUPPORTED_MODELS = [
     'gpt-4-0613',
     'gpt-4-32k-0613',
     'gpt-4-1106-preview',
-    'gpt-4-0125-preview'
+    'gpt-4-0125-preview',
+    'gpt-4-turbo-2024-04-09'
 ]
 DEFAULT_MODEL = 'gpt-3.5-turbo-0125'
 LESSONS = ['csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -71,6 +71,8 @@ def command_line_options():
                         help='Remove comments from student code before evaluating')
     parser.add_argument('-g', '--generate-confidence', action='store_true',
                         help='Generate confidence levels for each learning goal')
+    parser.add_argument('-w', '--workers', type=int, default=7,
+                        help='Number of workers to use for processing. Defaults to 7 workers.')
 
     args = parser.parse_args()
 
@@ -333,7 +335,7 @@ def main():
                 os.remove(file)
 
         # call label function to either call openAI or read from cache
-        with concurrent.futures.ThreadPoolExecutor(max_workers=7) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=options.workers) as executor:
             predicted_labels = list(executor.map(lambda student_file: read_and_label_student_work(prompt, rubric, student_file, examples, options, params, experiment_lesson_prefix, response_type), student_files))
 
         errors = [student_id for student_id, labels in predicted_labels if not labels]

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -397,7 +397,8 @@ def main():
                         accuracy_failures[lesson]['key_concepts'][key_concept]['accuracy_score'] = accuracy_by_criteria[key_concept]
                         accuracy_failures[lesson]['key_concepts'][key_concept]['threshold'] = accuracy_thresholds[lesson]['key_concepts'][key_concept]
 
-            os.system(f"open {output_file}")
+            if not is_pass_fail:
+                os.system(f"open {output_file}")
 
             if options.generate_confidence:
                 if is_pass_fail:


### PR DESCRIPTION
adds the newest turbo model. this was used to generate the release in https://github.com/code-dot-org/code-dot-org/pull/58290. this PR needs to be deployed to AI proxy before that PR is deployed, otherwise aiproxy will not recognize the new model. there are a couple of other tweaks to rubric tester in this PR, noted inline.

## Testing story

we don't have a great testing story for the main method of rubric tester, so the only testing has been manual:
* generated new accuracy results
* verified -w param is working
* verified only the exact match report is opened

## Accuracy

see https://github.com/code-dot-org/code-dot-org/pull/58290

## API Changes

this only adds to the API -- it doesn't change the behavior of any existing API behavior.