### PR TITLE
recover gracefully when openai returns 500 or times out

### DIFF
--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -20,3 +20,5 @@ DEFAULT_MODEL = 'gpt-3.5-turbo-0125'
 LESSONS = ['csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
 DEFAULT_DATASET_NAME = 'contractor-grades-batch-1-fall-2023'
 DEFAULT_EXPERIMENT_NAME = 'ai-rubrics-pilot-gpt-3.5-turbo'
+
+OPENAI_API_TIMEOUT = 150

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -9,7 +9,7 @@ import boto3
 from threading import Lock
 
 from typing import List, Dict, Any
-from lib.assessment.config import VALID_LABELS
+from lib.assessment.config import VALID_LABELS, OPENAI_API_TIMEOUT
 from lib.assessment.code_feature_extractor import CodeFeatures
 from lib.assessment.decision_trees import DecisionTrees
 
@@ -190,7 +190,7 @@ class Label:
         }
 
         # Post to the AI service
-        response = requests.post(api_url, headers=headers, json=data, timeout=120)
+        response = requests.post(api_url, headers=headers, json=data, timeout=OPENAI_API_TIMEOUT)
 
         if response.status_code == 500:
             logging.info(f"{student_id} Error calling the API: {response.status_code}")

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -193,16 +193,16 @@ class Label:
         response = requests.post(api_url, headers=headers, json=data, timeout=OPENAI_API_TIMEOUT)
 
         if response.status_code == 500:
-            logging.info(f"{student_id} Error calling the API: {response.status_code}")
-            logging.info(f"{student_id} Response body: {response.text}")
+            logging.warning(f"{student_id} Error calling the API: {response.status_code}")
+            logging.warning(f"{student_id} Response body: {response.text}")
             raise OpenaiServerError(f"Error calling OpenAI API: {response.text}")
         elif self._openai_context_length_exceeded(response):
             message = response.json().get('error', {}).get('message')
-            logging.error(f"{student_id} Request too large: {message}")
+            logging.warning(f"{student_id} Request too large: {message}")
             raise RequestTooLargeError(f"{student_id} {message}")
         elif response.status_code != 200:
             logging.error(f"{student_id} Error calling the API: {response.status_code}")
-            logging.info(f"{student_id} Response body: {response.text}")
+            logging.error(f"{student_id} Response body: {response.text}")
             return None
 
         info = response.json()
@@ -254,7 +254,7 @@ class Label:
         try:
             ai_result = self.ai_label_student_work(prompt, rubric, student_code, student_id, examples=examples, num_responses=num_responses, temperature=temperature, llm_model=llm_model, response_type=response_type)
         except requests.exceptions.ReadTimeout as exception:
-            logging.info(f"{student_id} request timed out in {(time.time() - start_time):.0f} seconds.")
+            logging.warning(f"{student_id} request timed out in {(time.time() - start_time):.0f} seconds.")
             raise exception
 
         # No assessment was possible
@@ -381,7 +381,7 @@ class Label:
                 raise e
             return None
         except RequestTooLargeError as e:
-            logging.info(f"{student_id} {choice_text} Request too large: {str(e)}")
+            logging.warning(f"{student_id} {choice_text} Request too large: {str(e)}")
             if reraise:
                 raise e
 

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -246,10 +246,9 @@ class Label:
         # Send data to LLM for assessment
         try:
             ai_result = self.ai_label_student_work(prompt, rubric, student_code, student_id, examples=examples, num_responses=num_responses, temperature=temperature, llm_model=llm_model, response_type=response_type)
-        except requests.exceptions.ReadTimeout:
-            logging.error(f"{student_id} request timed out in {(time.time() - start_time):.0f} seconds.")
-            ai_result = None
-
+        except requests.exceptions.ReadTimeout as exception:
+            logging.info(f"{student_id} request timed out in {(time.time() - start_time):.0f} seconds.")
+            raise exception
 
         # No assessment was possible
         if ai_result is None:

--- a/src/assessment.py
+++ b/src/assessment.py
@@ -14,7 +14,7 @@ from lib.assessment.config import DEFAULT_MODEL
 # Our assessment code
 from lib.assessment import assess
 from lib.assessment.assess import KeyConceptError
-from lib.assessment.label import InvalidResponseError, RequestTooLargeError
+from lib.assessment.label import InvalidResponseError, RequestTooLargeError, OpenaiServerError
 
 assessment_routes = Blueprint('assessment_routes', __name__)
 
@@ -57,6 +57,8 @@ def post_assessment():
         return f'InvalidResponseError: {str(e)}', 400
     except KeyConceptError as e:
         return e, 400
+    except OpenaiServerError as e:
+        return e, 503
     except requests.exceptions.ReadTimeout as e:
         return f"OpenAI timeout: #{e}: ", 504
 

--- a/src/assessment.py
+++ b/src/assessment.py
@@ -7,6 +7,7 @@ import os
 import openai
 import json
 import logging
+import requests
 
 from lib.assessment.config import DEFAULT_MODEL
 
@@ -56,6 +57,8 @@ def post_assessment():
         return f'InvalidResponseError: {str(e)}', 400
     except KeyConceptError as e:
         return e, 400
+    except requests.exceptions.ReadTimeout as e:
+        return f"OpenAI timeout: #{e}: ", 504
 
     if not isinstance(labels, dict) or not isinstance(labels.get("data"), list):
         return "response from AI or service not valid", 400

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -9,7 +9,7 @@ from io import StringIO
 import requests
 import pytest
 
-from lib.assessment.label import Label, InvalidResponseError, RequestTooLargeError
+from lib.assessment.label import Label, InvalidResponseError, RequestTooLargeError, OpenaiServerError
 
 
 @pytest.fixture
@@ -543,13 +543,33 @@ class TestAiLabelStudentWork:
             status_code=400,
         )
 
-        parsed_rubric = list(csv.DictReader(rubric.splitlines()))
-
         with pytest.raises(RequestTooLargeError) as error:
             label.ai_label_student_work(
                 prompt, rubric, code, student_id, examples(rubric), num_responses, temperature, llm_model
             )
         assert context_length_message in str(error.value)
+
+    def test_should_raise_service_unavailable_when_openai_returns_500(
+            self, requests_mock, openai_gpt_response, label, prompt, rubric, code, student_id,
+            examples, num_responses, temperature, llm_model):
+
+        mock_gpt_response = openai_gpt_response(
+            rubric=rubric,
+            num_responses=num_responses
+        )
+
+        requests_mock.post(
+            'https://api.openai.com/v1/chat/completions',
+            json=mock_gpt_response,
+            headers={'Content-Type': 'application/json'},
+            status_code=500,
+        )
+
+        with pytest.raises(OpenaiServerError) as error:
+            label.ai_label_student_work(
+                prompt, rubric, code, student_id, examples(rubric), num_responses, temperature, llm_model
+            )
+        assert 'openai' in str(error.value).lower()
 
     def test_should_return_data_as_none_when_ai_result_is_empty(self, requests_mock, mocker, openai_gpt_response, label, prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model):
         mock_gpt_response = openai_gpt_response(

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -744,7 +744,7 @@ class TestLabelStudentWork:
                 remove_comments=False
             )
 
-        assert any(filter(lambda x: ('request timed out' in x.message) and x.levelno == logging.INFO, caplog.records))
+        assert any(filter(lambda x: ('request timed out' in x.message) and x.levelno == logging.WARNING, caplog.records))
 
     def test_should_open_cached_responses_when_asked_and_they_exist(self, mocker, label, prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model):
         filename = f'cached_responses/{student_id}.json'

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -706,6 +706,8 @@ class TestLabelStudentWork:
         return gen_assessment
 
     def test_should_log_timeout(self, mocker, caplog, label, prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model):
+        caplog.set_level(logging.INFO)
+
         # Mock out static assessment
         mocker.patch.object(Label, 'test_for_blank_code').return_value = None
 
@@ -722,7 +724,7 @@ class TestLabelStudentWork:
                 remove_comments=False
             )
 
-        assert any(filter(lambda x: ('request timed out' in x.message) and x.levelno == logging.ERROR, caplog.records))
+        assert any(filter(lambda x: ('request timed out' in x.message) and x.levelno == logging.INFO, caplog.records))
 
     def test_should_open_cached_responses_when_asked_and_they_exist(self, mocker, label, prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model):
         filename = f'cached_responses/{student_id}.json'


### PR DESCRIPTION
## Depends on
* https://github.com/code-dot-org/code-dot-org/pull/58411

See that PR for details.

## Description

Finishes https://codedotorg.atlassian.net/browse/AITT-464
* when openai returns 500, aiproxy returns 503, with "openai" somewhere in the response text
* when the call to openai times out, aiproxy returns 504, with "openai" somewhere in the response text

## Testing story

- [x] new unit tests
- [x] end-to-end testing in previous PR

## Accuracy

no change to accuracy

## API Changes

API now returns 503 and 504 in some cases

