### PR TITLE
Grant ECS Task appropriate AWS Bedrock permissions

### DIFF
--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -151,6 +151,8 @@ Resources:
                   - bedrock:InvokeModel
                 Resource:
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2
+                  - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0
+                  - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
 
   ECSServiceAutoScalingRole:
     Type: AWS::IAM::Role

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -141,6 +141,16 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+      Policies:
+        - PolicyName: ECSTaskBedrockPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                Resource:
+                  - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2
 
   ECSServiceAutoScalingRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Description

This grants the AIProxy ECS Task permission to invoke specific Bedrock models. Additional model ARN's can be added here.

Note that for local development, you will need an alternative means of obtaining permissions.

## Links

- [AITT-650](https://codedotorg.atlassian.net/browse/AITT-650)
- [INF-1370](https://codedotorg.atlassian.net/browse/INF-1370)

## Testing story

@Nokondi Is currently testing locally with an IAM user with equivalent permission (though he has access to `*` model resources).

## Accuracy

n/a

## API Changes

n/a

## Follow-up work

n/a

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [ ] Accuracy against the dev set has been retested
- [ ] Changes in accuracy have been communicated
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
