### PR TITLE
rename assess.label() to validate_and_label()

### DIFF
--- a/lib/assessment/assess.py
+++ b/lib/assessment/assess.py
@@ -13,7 +13,7 @@ from lib.assessment.label import Label
 class KeyConceptError(Exception):
   pass
 
-def label(code, prompt, rubric, examples=[], api_key='', llm_model=DEFAULT_MODEL, num_responses=1, temperature=0.2, remove_comments=False, response_type='tsv', code_feature_extractor=None, lesson=None):
+def validate_and_label(code, prompt, rubric, examples=[], api_key='', llm_model=DEFAULT_MODEL, num_responses=1, temperature=0.2, remove_comments=False, response_type='tsv', code_feature_extractor=None, lesson=None):
   OPENAI_API_KEY = api_key
 
   # Set the key

--- a/src/assessment.py
+++ b/src/assessment.py
@@ -37,7 +37,7 @@ def post_assessment():
     llm_model = request.values.get("model", DEFAULT_MODEL)
 
     try:
-        labels = assess.label(
+        labels = assess.validate_and_label(
             code=request.values.get("code", ""),
             prompt=request.values.get("prompt", ""),
             rubric=request.values.get("rubric", ""),
@@ -91,7 +91,7 @@ def test_assessment():
         rubric = f.read()
 
     try:
-        labels = assess.label(
+        labels = assess.validate_and_label(
             code=code,
             prompt=prompt,
             rubric=rubric,
@@ -126,7 +126,7 @@ def test_assessment_blank():
         rubric = f.read()
 
     try:
-        labels = assess.label(
+        labels = assess.validate_and_label(
             code=code,
             prompt=prompt,
             rubric=rubric,
@@ -167,7 +167,7 @@ def test_assessment_examples():
         examples.append(f.read())
 
     try:
-        labels = assess.label(
+        labels = assess.validate_and_label(
             code=code,
             prompt=prompt,
             rubric=rubric,
@@ -208,7 +208,7 @@ def test_assessment_cfe():
         rubric = f.read()
 
     try:
-        labels = assess.label(
+        labels = assess.validate_and_label(
             code=code,
             prompt=prompt,
             rubric=rubric,

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -50,7 +50,7 @@ class TestPostAssessment:
         assert response.status_code == 400
 
     def test_should_return_413_on_request_too_large_error(self, mocker, client, randomstring):
-        mocker.patch('lib.assessment.assess.label').side_effect = RequestTooLargeError('')
+        mocker.patch('lib.assessment.assess.validate_and_label').side_effect = RequestTooLargeError('')
         os.environ['AIPROXY_API_KEY'] = 'test_key'
         response = client.post('/assessment', query_string={
           "code": randomstring(10),
@@ -96,7 +96,7 @@ class TestPostAssessment:
         assert response.status_code == 400
 
     def test_should_return_400_when_the_label_function_does_not_return_data(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         label_mock.return_value = []
 
         os.environ['AIPROXY_API_KEY'] = 'test_key'
@@ -115,7 +115,7 @@ class TestPostAssessment:
         assert response.status_code == 400
 
     def test_should_return_400_when_the_label_function_does_not_return_the_right_structure(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         label_mock.return_value = {
             'metadata': {},
             'data': {}
@@ -138,7 +138,7 @@ class TestPostAssessment:
 
     def test_should_pass_arguments_to_label_function(self, mocker, client, randomstring):
         response_type = 'json'
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         data = {
           "code": randomstring(10),
           "prompt": randomstring(10),
@@ -171,7 +171,7 @@ class TestPostAssessment:
         )
 
     def test_should_return_the_result_from_label_function_when_valid(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         label_mock.return_value = {
             'metadata': {},
             'data': [
@@ -209,7 +209,7 @@ class TestPostTestAssessment:
     """
 
     def test_should_return_400_on_openai_error(self, mocker, client, randomstring):
-        mocker.patch('lib.assessment.assess.label').side_effect = openai.error.InvalidRequestError('', '')
+        mocker.patch('lib.assessment.assess.validate_and_label').side_effect = openai.error.InvalidRequestError('', '')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         os.environ['AIPROXY_API_KEY'] = 'test_key'
@@ -258,7 +258,7 @@ class TestPostTestAssessment:
         assert response.status_code == 400
 
     def test_should_return_400_when_the_label_function_does_not_return_data(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         label_mock.return_value = []
@@ -277,7 +277,7 @@ class TestPostTestAssessment:
         assert response.status_code == 400
 
     def test_should_return_400_when_the_label_function_does_not_return_the_right_structure(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         label_mock.return_value = {
@@ -299,7 +299,7 @@ class TestPostTestAssessment:
         assert response.status_code == 400
 
     def test_should_return_the_result_from_label_function_when_valid(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         label_mock.return_value = {
@@ -335,7 +335,7 @@ class TestPostBlankAssessment:
     """
 
     def test_should_return_400_on_openai_error(self, mocker, client, randomstring):
-        mocker.patch('lib.assessment.assess.label').side_effect = openai.error.InvalidRequestError('', '')
+        mocker.patch('lib.assessment.assess.validate_and_label').side_effect = openai.error.InvalidRequestError('', '')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         os.environ['AIPROXY_API_KEY'] = 'test_key'
@@ -381,7 +381,7 @@ class TestPostBlankAssessment:
         assert response.status_code == 400
 
     def test_should_return_400_when_the_label_function_does_not_return_data(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         label_mock.return_value = []
@@ -399,7 +399,7 @@ class TestPostBlankAssessment:
         assert response.status_code == 400
 
     def test_should_return_400_when_the_label_function_does_not_return_the_right_structure(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         label_mock.return_value = {
@@ -420,7 +420,7 @@ class TestPostBlankAssessment:
         assert response.status_code == 400
 
     def test_should_pass_arguments_including_blank_code_to_label_function(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         data = {
@@ -448,7 +448,7 @@ class TestPostBlankAssessment:
         )
 
     def test_should_return_the_result_from_label_function_when_valid(self, mocker, client, randomstring):
-        label_mock = mocker.patch('lib.assessment.assess.label')
+        label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
         mock_open = mocker.mock_open(read_data='file data')
         mock_file = mocker.patch('builtins.open', mock_open)
         label_mock.return_value = {

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -3,13 +3,13 @@ import os
 import pytest
 
 from lib.assessment.label import Label
-from lib.assessment.assess import label, KeyConceptError
+from lib.assessment.assess import validate_and_label, KeyConceptError
 
 
 def test_label_should_pass_arguments_along(
         mocker, code, prompt, rubric, examples, openai_api_key,
         llm_model, num_responses, temperature, remove_comments):
-    """ Tests lib.assessment.assess.label()
+    """ Tests lib.assessment.assess.validate_and_label()
     """
 
     # import test data
@@ -29,7 +29,7 @@ def test_label_should_pass_arguments_along(
     label_student_work = mocker.patch.object(Label, 'label_student_work')
 
     # Actually call the method
-    label(code, prompt, rubric,
+    validate_and_label(code, prompt, rubric,
         examples=examples,
         api_key=openai_api_key,
         llm_model=llm_model,
@@ -57,14 +57,14 @@ def test_label_should_pass_arguments_along(
 def test_label_should_set_api_key_in_env_var(
         mocker, code, prompt, rubric, examples, openai_api_key,
         llm_model, num_responses, temperature, remove_comments):
-    """ Tests lib.assessment.assess.label()
+    """ Tests lib.assessment.assess.validate_and_label()
     """
 
     # Mock the Label() class
     label_student_work = mocker.patch.object(Label, 'label_student_work')
 
     # Actually call the method
-    label(code, prompt, rubric,
+    validate_and_label(code, prompt, rubric,
         examples=examples(rubric, 0),
         api_key=openai_api_key,
         llm_model=llm_model,
@@ -80,14 +80,14 @@ def test_label_should_set_api_key_in_env_var(
 def test_label_should_return_empty_result_when_no_api_key(
         mocker, code, prompt, rubric, examples,
         llm_model, num_responses, temperature, remove_comments):
-    """ Tests lib.assessment.assess.label() (without an api-key)
+    """ Tests lib.assessment.assess.validate_and_label() (without an api-key)
     """
 
     # Mock the Label() class
     label_student_work = mocker.patch.object(Label, 'label_student_work')
 
     # Actually call the method
-    result = label(code, prompt, rubric,
+    result = validate_and_label(code, prompt, rubric,
         examples=examples(rubric, 0),
         llm_model=llm_model,
         num_responses=num_responses,
@@ -102,7 +102,7 @@ def test_label_should_return_empty_result_when_no_api_key(
 def test_label_should_return_empty_result_when_example_and_rubric_key_concepts_mismatch(
         mocker, code, prompt, rubric, examples, openai_api_key,
         llm_model, num_responses, temperature, remove_comments):
-    """ Tests lib.assessment.assess.label() (without an api-key)
+    """ Tests lib.assessment.assess.validate_and_label() (without an api-key)
     """
     # Mock the Label() class
     label_student_work = mocker.patch.object(Label, 'label_student_work')
@@ -114,7 +114,7 @@ def test_label_should_return_empty_result_when_example_and_rubric_key_concepts_m
         example.append(f.read())
 
     with pytest.raises(KeyConceptError):
-        label(code, prompt, rubric,
+        validate_and_label(code, prompt, rubric,
             examples=example,
             api_key=openai_api_key,
             llm_model=llm_model,
@@ -127,7 +127,7 @@ def test_label_should_return_empty_result_when_example_and_rubric_key_concepts_m
 def test_label_should_call_label_student_work_with_api_key_in_env_var(
         mocker, code, prompt, rubric, examples, openai_api_key,
         llm_model, num_responses, temperature, remove_comments):
-    """ Tests lib.assessment.assess.label() (without an api-key)
+    """ Tests lib.assessment.assess.validate_and_label() (without an api-key)
     """
 
     # Set the environment variable
@@ -137,7 +137,7 @@ def test_label_should_call_label_student_work_with_api_key_in_env_var(
     label_student_work = mocker.patch.object(Label, 'label_student_work')
 
     # Actually call the method
-    result = label(code, prompt, rubric,
+    result = validate_and_label(code, prompt, rubric,
         examples=examples(rubric, 0),
         llm_model=llm_model,
         num_responses=num_responses,
@@ -146,7 +146,7 @@ def test_label_should_call_label_student_work_with_api_key_in_env_var(
     )
 
     # Actually call the method (without the api key)
-    label(code, prompt, rubric,
+    validate_and_label(code, prompt, rubric,
         examples=examples(rubric, 0),
         llm_model=llm_model,
         num_responses=num_responses,


### PR DESCRIPTION
quick refactor PR to make it a bit easier to navigate the aiproxy codebase, by making it easier to tell the difference between references to the Label class and the label method. This PR just renames the `label` method to `validate_and_label`.

## Testing story

updated unit tests