### PR TITLE
add integration tests from flask endpoint to AI API call

### DIFF
--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -144,7 +144,7 @@ class Label:
         if '\\"Stretch\\"' in response_body["content"][0]["text"]:
             response_body["content"][0]["text"] = response_body["content"][0]["text"].replace('\\"Stretch\\"', "“Stretch”")   
 
-        data = self.get_response_data_if_valid(response_body, rubric, student_id, response_type='json')
+        data = self.get_response_data_if_valid(response_body, rubric, student_id, response_type='json', reraise=True)
 
         return {
             'metadata': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,6 @@ def mock_env_vars(request):
         yield
     else:
         from unittest.mock import patch
-        print("no env vars")
         # Ensure the os.environ passes out a new dictionary
         with patch.dict(os.environ, {}, clear=True):
             yield

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -52,7 +52,7 @@ def lesson_11_request_data(stub_code, stub_prompt, lesson_11_rubric, bedrock_cla
     yield request_data
 
 @pytest.fixture
-def lesson_11_response_data():
+def lesson_11_eval():
     yield [
         {
             "Key Concept": "Program Development - Program Sequence",
@@ -77,9 +77,9 @@ def lesson_11_response_data():
         }
     ]
 
-def get_bedrock_claude_response_body(response_data):
-    response_json = json.dumps(response_data)
-    body_data = {
+def get_bedrock_claude_response_data(eval_data):
+    eval_json = json.dumps(eval_data)
+    return {
         "id": "msg_bdrk_01234567890abcdefghijklm",
         "type": "message",
         "role": "assistant",
@@ -87,7 +87,7 @@ def get_bedrock_claude_response_body(response_data):
         "content": [
             {
                 "type": "text",
-                "text": response_json
+                "text": eval_json
             }
         ],
         "stop_reason": "end_turn",
@@ -97,14 +97,22 @@ def get_bedrock_claude_response_body(response_data):
             "output_tokens": 972
         }
     }
-    return json.dumps(body_data, indent=2)
 
 @pytest.fixture
-def lesson_11_response_body(lesson_11_response_data):
-    yield get_bedrock_claude_response_body(lesson_11_response_data)
+def lesson_11_response_body(lesson_11_eval):
+    body_data = get_bedrock_claude_response_data(lesson_11_eval)
+    yield json.dumps(body_data)
 
 @pytest.fixture
-def lesson_11_response_body_mismatched(lesson_11_response_data):
-    response_data = lesson_11_response_data
-    response_data[0]["Key Concept"] = "Bogus Key Concept"
-    yield get_bedrock_claude_response_body(response_data)
+def lesson_11_response_body_mismatched(lesson_11_eval):
+    eval = lesson_11_eval
+    eval[0]["Key Concept"] = "Bogus Key Concept"
+    body_data = get_bedrock_claude_response_data(eval)
+    yield json.dumps(body_data)
+
+@pytest.fixture
+def lesson_11_response_body_too_large():
+    unparsable_json = '["unparsable JSON"'
+    body_data = get_bedrock_claude_response_data(unparsable_json)
+    body_data['stop_reason'] = 'max_tokens'
+    yield json.dumps(body_data)

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -100,19 +100,19 @@ def get_bedrock_claude_response_data(eval_data):
 
 @pytest.fixture
 def lesson_11_response_body(lesson_11_eval):
-    body_data = get_bedrock_claude_response_data(lesson_11_eval)
-    yield json.dumps(body_data)
+    response_data = get_bedrock_claude_response_data(lesson_11_eval)
+    yield json.dumps(response_data)
 
 @pytest.fixture
 def lesson_11_response_body_mismatched(lesson_11_eval):
     eval = lesson_11_eval
     eval[0]["Key Concept"] = "Bogus Key Concept"
-    body_data = get_bedrock_claude_response_data(eval)
-    yield json.dumps(body_data)
+    response_data = get_bedrock_claude_response_data(eval)
+    yield json.dumps(response_data)
 
 @pytest.fixture
 def lesson_11_response_body_too_large():
     unparsable_json = '["unparsable JSON"'
-    body_data = get_bedrock_claude_response_data(unparsable_json)
-    body_data['stop_reason'] = 'max_tokens'
-    yield json.dumps(body_data)
+    response_data = get_bedrock_claude_response_data(unparsable_json)
+    response_data['stop_reason'] = 'max_tokens'
+    yield json.dumps(response_data)

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -142,6 +142,9 @@ def lesson_11_claude_response_body_mismatched(lesson_11_eval):
     response_data = get_claude_response_data(eval)
     yield json.dumps(response_data)
 
+# Our response handling logic raises RequestTooLargeError when it cannot find or parse the response JSON,
+# and the stop reason indicates that the response was truncated:
+# https://github.com/code-dot-org/aiproxy/blob/3c5b70a4de4bc93f5def2541db1fb7081a05a6da/lib/assessment/label.py#L427-L437
 @pytest.fixture
 def lesson_11_claude_response_body_too_large():
     unparsable_json = '["unparsable JSON"'

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -12,12 +12,11 @@ def lesson_11_rubric():
     """ Creates a rubric in CSV format, based on csd3-2023-L11.
     """
 
-    output = """Key Concept,Extensive Evidence,Convincing Evidence,Limited Evidence,No Evidence
+    yield """Key Concept,Extensive Evidence,Convincing Evidence,Limited Evidence,No Evidence
 Program Development - Program Sequence,You sequenced the program well and and all elements on the screen appear as intended.,Your program may contain a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.,"Your program has significant sequencing errors, resulting in many elements unintentionally hidden or overlapping others.","Errors in program sequencing are significant enough to keep the output from resembling the intended scene."
 Modularity - Sprites and Sprite Properties,"At least 2 sprites created, each with at least one property updated after creation.","At least 1 sprite created with at least one property updated after creation.","At least 1 sprite created. No properties updated after creation.","No sprites are used in the program."
 Position - Elements and the Coordinate System,"At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system.","At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system.","A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text)","No elements (shapes, sprites, or text) are placed on the screen using the coordinate system."
 """
-    yield output
 
 @pytest.fixture
 def stub_code():
@@ -42,7 +41,7 @@ def openai_model():
 @pytest.fixture
 def lesson_11_claude_request_data(stub_code, stub_prompt, lesson_11_rubric, bedrock_claude_model):
     rubric = lesson_11_rubric
-    request_data = {
+    yield {
         "code": stub_code,
         "prompt": stub_prompt,
         "rubric": rubric,
@@ -53,7 +52,6 @@ def lesson_11_claude_request_data(stub_code, stub_prompt, lesson_11_rubric, bedr
         "num-responses": "2",
         "temperature": "0.2",
     }
-    yield request_data
 
 @pytest.fixture
 def lesson_11_openai_request_data(lesson_11_claude_request_data, openai_model):

--- a/tests/routes/conftest.py
+++ b/tests/routes/conftest.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 @pytest.fixture(autouse=True)
@@ -5,3 +6,105 @@ def mock_requests(requests_mock):
     """ Ensure no network request goes out during route tests, here.
     """
     pass
+
+@pytest.fixture
+def lesson_11_rubric():
+    """ Creates a rubric in CSV format, based on csd3-2023-L11.
+    """
+
+    output = """Key Concept,Extensive Evidence,Convincing Evidence,Limited Evidence,No Evidence
+Program Development - Program Sequence,You sequenced the program well and and all elements on the screen appear as intended.,Your program may contain a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.,"Your program has significant sequencing errors, resulting in many elements unintentionally hidden or overlapping others.","Errors in program sequencing are significant enough to keep the output from resembling the intended scene."
+Modularity - Sprites and Sprite Properties,"At least 2 sprites created, each with at least one property updated after creation.","At least 1 sprite created with at least one property updated after creation.","At least 1 sprite created. No properties updated after creation.","No sprites are used in the program."
+Position - Elements and the Coordinate System,"At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system.","At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system.","A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text)","No elements (shapes, sprites, or text) are placed on the screen using the coordinate system."
+"""
+    yield output
+
+@pytest.fixture
+def stub_code():
+    yield 'stub-code'
+
+@pytest.fixture
+def stub_prompt():
+    yield 'stub-prompt'
+
+@pytest.fixture
+def claude_model():
+    yield 'anthropic.claude-3-5-sonnet-20240620-v1:0'
+
+@pytest.fixture
+def bedrock_claude_model(claude_model):
+    yield 'bedrock.' + claude_model
+
+@pytest.fixture
+def lesson_11_request_data(stub_code, stub_prompt, lesson_11_rubric, bedrock_claude_model):
+    rubric = lesson_11_rubric
+    request_data = {
+        "code": stub_code,
+        "prompt": stub_prompt,
+        "rubric": rubric,
+        "api-key": 'test-api-key',
+        "examples": "[]",
+        "model": bedrock_claude_model,
+        "remove-comments": "1",
+        "num-responses": "2",
+        "temperature": "0.2",
+    }
+    yield request_data
+
+@pytest.fixture
+def lesson_11_response_data():
+    yield [
+        {
+            "Key Concept": "Program Development - Program Sequence",
+            "Observations": "The program appears to be well-sequenced, with background set first, sprites created and positioned, sprite properties set, sprites drawn, and text added last.",
+            "Evidence": "Lines 1-9: The program sets the background, creates and positions sprites, sets their properties, and draws them in the correct order.\n`background(\"black\");\nvar animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);\nanimalhead_duck1.setAnimation(\"animalhead_duck1\");\nanimalhead_frog_1.setAnimation(\"animalhead_frog_1\");\nanimalhead_frog_1.scale = 0.4;\nanimalhead_duck1.scale = 0.4;\ndrawSprites();`\n\nLines 10-12: Text is added after sprites are drawn.\n`textSize(20);\nfill(\"white\");\ntext(\"Fortnite\", 175, 200);`",
+            "Reason": "The program demonstrates a logical sequence of operations. The background is set first, then sprites are created and their properties are set. The drawSprites() function is called to render the sprites, and finally, the text is added. This sequence ensures that all elements appear as intended, with no overlapping or hiding issues. Decision: Extensive Evidence",
+            "Grade": "Extensive Evidence"
+        },
+        {
+            "Key Concept": "Modularity - Sprites and Sprite Properties",
+            "Observations": "The program creates two sprites and updates properties for both after creation.",
+            "Evidence": "Lines 2-3: Two sprites are created.\n`var animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);`\n\nLines 4-7: Properties of both sprites are updated after creation.\n`animalhead_duck1.setAnimation(\"animalhead_duck1\");\nanimalhead_frog_1.setAnimation(\"animalhead_frog_1\");\nanimalhead_frog_1.scale = 0.4;\nanimalhead_duck1.scale = 0.4;`",
+            "Reason": "The program creates two distinct sprites: animalhead_duck1 and animalhead_frog_1. For both sprites, it sets the animation and scale properties after creation. This meets the criteria for Extensive Evidence as there are at least 2 sprites created, each with at least one property updated after creation. Decision: Extensive Evidence",
+            "Grade": "Extensive Evidence"
+        },
+        {
+            "Key Concept": "Position - Elements and the Coordinate System",
+            "Observations": "The program places two sprites and one line of text using the coordinate system. No shapes are created.",
+            "Evidence": "Lines 2-3: Two sprites are positioned using coordinates.\n`var animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);`\n\nLine 12: One line of text is positioned using coordinates.\n`text(\"Fortnite\", 175, 200);`",
+            "Reason": "The program demonstrates the use of the coordinate system to place elements on the screen. It positions two sprites (animalhead_duck1 and animalhead_frog_1) and one line of text (\"Fortnite\") using x and y coordinates. However, it does not create any shapes using functions like rect, ellipse, circle, quad, or triangle. According to the rubric, for Convincing Evidence, we need at least 1 shape, 2 sprites, and 1 line of text. While the program meets the criteria for sprites and text, it lacks any shapes. Therefore, it falls under the Limited Evidence category. Decision: Limited Evidence",
+            "Grade": "Limited Evidence"
+        }
+    ]
+
+def get_bedrock_claude_response_body(response_data):
+    response_json = json.dumps(response_data)
+    body_data = {
+        "id": "msg_bdrk_01234567890abcdefghijklm",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20240620",
+        "content": [
+            {
+                "type": "text",
+                "text": response_json
+            }
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 1397,
+            "output_tokens": 972
+        }
+    }
+    return json.dumps(body_data, indent=2)
+
+@pytest.fixture
+def lesson_11_response_body(lesson_11_response_data):
+    yield get_bedrock_claude_response_body(lesson_11_response_data)
+
+@pytest.fixture
+def lesson_11_response_body_mismatched(lesson_11_response_data):
+    response_data = lesson_11_response_data
+    response_data[0]["Key Concept"] = "Bogus Key Concept"
+    yield get_bedrock_claude_response_body(response_data)

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -1,14 +1,67 @@
 import io
-import json
 import openai
 import os
-import pytest
 
 from lib.assessment.label import Label, RequestTooLargeError
 
 class TestPostAssessment:
     """ Tests POST to '/assessment' to start an assessment.
+
+    These tests attempt to cover the /assessment route end-to-end, stubbing out only the bedrock client.
     """
+
+    def test_succeeds_when_bedrock_returns_valid_response(self, mocker, client, stub_code, stub_prompt, lesson_11_rubric, claude_model, lesson_11_request_data, lesson_11_response_body):
+        # stub the bedrock response
+        response_body = lesson_11_response_body
+        invoke_model_response = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'body': io.StringIO(response_body)}
+        class mock_bedrock_client:
+            def invoke_model(body, modelId, accept, contentType):
+                assert stub_code in body
+                assert stub_prompt in body
+                rubric_headers = lesson_11_rubric.split('\n')[0]
+                assert rubric_headers in body
+                assert modelId == claude_model
+                assert accept == 'application/json'
+                assert contentType == 'application/json'
+                return invoke_model_response
+        get_bedrock_client_mock = mocker.patch.object(
+            Label,
+            'get_bedrock_client',
+            return_value=mock_bedrock_client
+        )
+
+        # send the flask request
+        request_data = lesson_11_request_data
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string=request_data, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+
+        assert response.status_code == 200
+
+        # check that get_bedrock_client_mock was called
+        get_bedrock_client_mock.assert_called_once()
+
+    def test_returns_4xx_when_bedrock_returns_mismatched_key_concept(self, mocker, client, lesson_11_request_data, lesson_11_response_body_mismatched):
+        # stub the bedrock response
+        response_body = lesson_11_response_body_mismatched
+        invoke_model_response = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'body': io.StringIO(response_body)}
+        class mock_bedrock_client:
+            def invoke_model(body, modelId, accept, contentType):
+                return invoke_model_response
+        get_bedrock_client_mock = mocker.patch.object(
+            Label,
+            'get_bedrock_client',
+            return_value=mock_bedrock_client
+        )
+
+        # send the flask request
+        request_data = lesson_11_request_data
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string=request_data, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+
+        assert response.status_code == 400
+
+        # check that get_bedrock_client_mock was called
+        get_bedrock_client_mock.assert_called_once()
 
     def test_should_return_400_when_no_code(self, client, randomstring):
         os.environ['AIPROXY_API_KEY'] = 'test_key'
@@ -97,6 +150,13 @@ class TestPostAssessment:
           "temperature": "x",
         }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
         assert response.status_code == 400
+
+
+class TestPostAssessmentUnitTests:
+    """ Tests POST to '/assessment' to start an assessment.
+
+    These tests stub out the Label class to test the API endpoint in isolation.
+    """
 
     def test_should_return_400_when_the_label_function_does_not_return_data(self, mocker, client, randomstring):
         label_mock = mocker.patch('lib.assessment.assess.validate_and_label')
@@ -205,168 +265,6 @@ class TestPostAssessment:
 
         assert response.status_code == 200
         assert response.json == label_mock.return_value
-
-
-@pytest.fixture
-def lesson_11_rubric():
-    """ Creates a rubric in CSV format, based on csd3-2023-L11.
-    """
-
-    output = """Key Concept,Extensive Evidence,Convincing Evidence,Limited Evidence,No Evidence
-Program Development - Program Sequence,You sequenced the program well and and all elements on the screen appear as intended.,Your program may contain a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.,"Your program has significant sequencing errors, resulting in many elements unintentionally hidden or overlapping others.","Errors in program sequencing are significant enough to keep the output from resembling the intended scene."
-Modularity - Sprites and Sprite Properties,"At least 2 sprites created, each with at least one property updated after creation.","At least 1 sprite created with at least one property updated after creation.","At least 1 sprite created. No properties updated after creation.","No sprites are used in the program."
-Position - Elements and the Coordinate System,"At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system.","At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system.","A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text)","No elements (shapes, sprites, or text) are placed on the screen using the coordinate system."
-"""
-    yield output
-
-@pytest.fixture
-def stub_code():
-    yield 'stub-code'
-
-@pytest.fixture
-def stub_prompt():
-    yield 'stub-prompt'
-
-@pytest.fixture
-def claude_model():
-    yield 'anthropic.claude-3-5-sonnet-20240620-v1:0'
-
-@pytest.fixture
-def bedrock_claude_model(claude_model):
-    yield 'bedrock.' + claude_model
-
-@pytest.fixture
-def lesson_11_request_data(stub_code, stub_prompt, lesson_11_rubric, bedrock_claude_model):
-    rubric = lesson_11_rubric
-    request_data = {
-        "code": stub_code,
-        "prompt": stub_prompt,
-        "rubric": rubric,
-        "api-key": 'test-api-key',
-        "examples": "[]",
-        "model": bedrock_claude_model,
-        "remove-comments": "1",
-        "num-responses": "2",
-        "temperature": "0.2",
-    }
-    yield request_data
-
-@pytest.fixture
-def lesson_11_response_data():
-    yield [
-        {
-            "Key Concept": "Program Development - Program Sequence",
-            "Observations": "The program appears to be well-sequenced, with background set first, sprites created and positioned, sprite properties set, sprites drawn, and text added last.",
-            "Evidence": "Lines 1-9: The program sets the background, creates and positions sprites, sets their properties, and draws them in the correct order.\n`background(\"black\");\nvar animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);\nanimalhead_duck1.setAnimation(\"animalhead_duck1\");\nanimalhead_frog_1.setAnimation(\"animalhead_frog_1\");\nanimalhead_frog_1.scale = 0.4;\nanimalhead_duck1.scale = 0.4;\ndrawSprites();`\n\nLines 10-12: Text is added after sprites are drawn.\n`textSize(20);\nfill(\"white\");\ntext(\"Fortnite\", 175, 200);`",
-            "Reason": "The program demonstrates a logical sequence of operations. The background is set first, then sprites are created and their properties are set. The drawSprites() function is called to render the sprites, and finally, the text is added. This sequence ensures that all elements appear as intended, with no overlapping or hiding issues. Decision: Extensive Evidence",
-            "Grade": "Extensive Evidence"
-        },
-        {
-            "Key Concept": "Modularity - Sprites and Sprite Properties",
-            "Observations": "The program creates two sprites and updates properties for both after creation.",
-            "Evidence": "Lines 2-3: Two sprites are created.\n`var animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);`\n\nLines 4-7: Properties of both sprites are updated after creation.\n`animalhead_duck1.setAnimation(\"animalhead_duck1\");\nanimalhead_frog_1.setAnimation(\"animalhead_frog_1\");\nanimalhead_frog_1.scale = 0.4;\nanimalhead_duck1.scale = 0.4;`",
-            "Reason": "The program creates two distinct sprites: animalhead_duck1 and animalhead_frog_1. For both sprites, it sets the animation and scale properties after creation. This meets the criteria for Extensive Evidence as there are at least 2 sprites created, each with at least one property updated after creation. Decision: Extensive Evidence",
-            "Grade": "Extensive Evidence"
-        },
-        {
-            "Key Concept": "Position - Elements and the Coordinate System",
-            "Observations": "The program places two sprites and one line of text using the coordinate system. No shapes are created.",
-            "Evidence": "Lines 2-3: Two sprites are positioned using coordinates.\n`var animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);`\n\nLine 12: One line of text is positioned using coordinates.\n`text(\"Fortnite\", 175, 200);`",
-            "Reason": "The program demonstrates the use of the coordinate system to place elements on the screen. It positions two sprites (animalhead_duck1 and animalhead_frog_1) and one line of text (\"Fortnite\") using x and y coordinates. However, it does not create any shapes using functions like rect, ellipse, circle, quad, or triangle. According to the rubric, for Convincing Evidence, we need at least 1 shape, 2 sprites, and 1 line of text. While the program meets the criteria for sprites and text, it lacks any shapes. Therefore, it falls under the Limited Evidence category. Decision: Limited Evidence",
-            "Grade": "Limited Evidence"
-        }
-    ]
-
-def get_bedrock_claude_response_body(response_data):
-    response_json = json.dumps(response_data)
-    body_data = {
-        "id": "msg_bdrk_01234567890abcdefghijklm",
-        "type": "message",
-        "role": "assistant",
-        "model": "claude-3-5-sonnet-20240620",
-        "content": [
-            {
-                "type": "text",
-                "text": response_json
-            }
-        ],
-        "stop_reason": "end_turn",
-        "stop_sequence": None,
-        "usage": {
-            "input_tokens": 1397,
-            "output_tokens": 972
-        }
-    }
-    return json.dumps(body_data, indent=2)
-
-@pytest.fixture
-def lesson_11_response_body(lesson_11_response_data):
-    yield get_bedrock_claude_response_body(lesson_11_response_data)
-
-@pytest.fixture
-def lesson_11_response_body_mismatched(lesson_11_response_data):
-    response_data = lesson_11_response_data
-    response_data[0]["Key Concept"] = "Bogus Key Concept"
-    yield get_bedrock_claude_response_body(response_data)
-
-class TestIntegrationPostAssessment:
-    """ Tests POST to '/assessment' to start an assessment.
-
-    This is an integration test because it tests all the way to the AI API request, rather than just checking what gets passed to Label.
-    """
-
-    def test_succeeds_when_bedrock_returns_valid_response(self, mocker, client, stub_code, stub_prompt, lesson_11_rubric, claude_model, lesson_11_request_data, lesson_11_response_body):
-        # stub the bedrock response
-        response_body = lesson_11_response_body
-        invoke_model_response = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'body': io.StringIO(response_body)}
-        class mock_bedrock_client:
-            def invoke_model(body, modelId, accept, contentType):
-                assert stub_code in body
-                assert stub_prompt in body
-                rubric_headers = lesson_11_rubric.split('\n')[0]
-                assert rubric_headers in body
-                assert modelId == claude_model
-                assert accept == 'application/json'
-                assert contentType == 'application/json'
-                return invoke_model_response
-        get_bedrock_client_mock = mocker.patch.object(
-            Label,
-            'get_bedrock_client',
-            return_value=mock_bedrock_client
-        )
-
-        # send the flask request
-        request_data = lesson_11_request_data
-        os.environ['AIPROXY_API_KEY'] = 'test_key'
-        response = client.post('/assessment', query_string=request_data, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-
-        assert response.status_code == 200
-
-        # check that get_bedrock_client_mock was called
-        get_bedrock_client_mock.assert_called_once()
-
-    def test_returns_4xx_when_bedrock_returns_mismatched_key_concept(self, mocker, client, lesson_11_request_data, lesson_11_response_body_mismatched):
-        # stub the bedrock response
-        response_body = lesson_11_response_body_mismatched
-        invoke_model_response = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'body': io.StringIO(response_body)}
-        class mock_bedrock_client:
-            def invoke_model(body, modelId, accept, contentType):
-                return invoke_model_response
-        get_bedrock_client_mock = mocker.patch.object(
-            Label,
-            'get_bedrock_client',
-            return_value=mock_bedrock_client
-        )
-
-        # send the flask request
-        request_data = lesson_11_request_data
-        os.environ['AIPROXY_API_KEY'] = 'test_key'
-        response = client.post('/assessment', query_string=request_data, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-
-        assert response.status_code == 400
-
-        # check that get_bedrock_client_mock was called
-        get_bedrock_client_mock.assert_called_once()
 
 
 class TestPostTestAssessment:

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -105,21 +105,35 @@ class TestPostAssessment:
         }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
         assert response.status_code == 400
 
-    def test_should_return_413_on_request_too_large_error(self, mocker, client, randomstring):
-        mocker.patch('lib.assessment.assess.validate_and_label').side_effect = RequestTooLargeError('')
+    def test_should_return_413_on_request_too_large_error(self, mocker, client, randomstring, lesson_11_rubric, bedrock_claude_model, lesson_11_response_body_too_large):
+        # stub the bedrock response
+        response_body = lesson_11_response_body_too_large
+        invoke_model_response = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'body': io.StringIO(response_body)}
+        class mock_bedrock_client:
+            def invoke_model(body, modelId, accept, contentType):
+                return invoke_model_response
+        get_bedrock_client_mock = mocker.patch.object(
+            Label,
+            'get_bedrock_client',
+            return_value=mock_bedrock_client
+        )
+
+        # send the flask request
         os.environ['AIPROXY_API_KEY'] = 'test_key'
         response = client.post('/assessment', query_string={
           "code": randomstring(10),
           "prompt": randomstring(10),
-          "rubric": randomstring(10),
+          "rubric": lesson_11_rubric,
           "api-key": randomstring(10),
           "examples": "[]",
-          "model": randomstring(10),
+          "model": bedrock_claude_model,
           "remove-comments": "1",
           "num-responses": "1",
           "temperature": "0.2",
         }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
         assert response.status_code == 413
+
+        get_bedrock_client_mock.assert_called_once()
 
     def test_should_return_400_when_passing_not_a_number_to_num_responses(self, client, randomstring):
         os.environ['AIPROXY_API_KEY'] = 'test_key'
@@ -260,8 +274,6 @@ class TestPostAssessmentUnitTests:
 
         os.environ['AIPROXY_API_KEY'] = 'test_key'
         response = client.post('/assessment', query_string=data, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-
-        print(response.data)
 
         assert response.status_code == 200
         assert response.json == label_mock.return_value
@@ -498,7 +510,6 @@ class TestPostBlankAssessment:
         }
         os.environ['AIPROXY_API_KEY'] = 'test_key'
         response = client.post('/test/assessment/blank', query_string=data, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-        print(response.data)
         label_mock.assert_called_with(
             code='',
             prompt='file data',

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -1,7 +1,10 @@
+import io
+import json
 import openai
 import os
+import pytest
 
-from lib.assessment.label import RequestTooLargeError
+from lib.assessment.label import Label, RequestTooLargeError
 
 class TestPostAssessment:
     """ Tests POST to '/assessment' to start an assessment.
@@ -202,6 +205,117 @@ class TestPostAssessment:
 
         assert response.status_code == 200
         assert response.json == label_mock.return_value
+
+
+@pytest.fixture
+def lesson_11_rubric():
+    """ Creates a rubric in CSV format, based on csd3-2023-L11.
+    """
+
+    output = """Key Concept,Extensive Evidence,Convincing Evidence,Limited Evidence,No Evidence
+Program Development - Program Sequence,You sequenced the program well and and all elements on the screen appear as intended.,Your program may contain a few incorrectly sequenced code resulting in a few elements hidden behind others unintentionally.,"Your program has significant sequencing errors, resulting in many elements unintentionally hidden or overlapping others.","Errors in program sequencing are significant enough to keep the output from resembling the intended scene."
+Modularity - Sprites and Sprite Properties,"At least 2 sprites created, each with at least one property updated after creation.","At least 1 sprite created with at least one property updated after creation.","At least 1 sprite created. No properties updated after creation.","No sprites are used in the program."
+Position - Elements and the Coordinate System,"At least 2 shapes, 2 sprites, and 2 lines of text are placed correctly on the screen using the coordinate system.","At least 1 shape, 2 sprites, and 1 line of text are placed on the screen using the coordinate system.","A cumulative of at least a total of 3 elements are placed on the screen using the coordinate system (e.g 2 sprites & 1 line of text or 1 sprite, 1 shape, & 1 line of text)","No elements (shapes, sprites, or text) are placed on the screen using the coordinate system."
+"""
+    yield output
+
+@pytest.fixture
+def lesson_11_request_data(lesson_11_rubric):
+    rubric = lesson_11_rubric
+    request_data = {
+        "code": 'test-code',
+        "prompt": 'test-prompt',
+        "rubric": rubric,
+        "api-key": 'test-api-key',
+        "examples": "[]",
+        "model": 'bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0',
+        "remove-comments": "1",
+        "num-responses": "2",
+        "temperature": "0.2",
+    }
+    yield request_data
+
+@pytest.fixture
+def lesson_11_response_json():
+    response_data = [
+        {
+            "Key Concept": "Program Development - Program Sequence",
+            "Observations": "The program appears to be well-sequenced, with background set first, sprites created and positioned, sprite properties set, sprites drawn, and text added last.",
+            "Evidence": "Lines 1-9: The program sets the background, creates and positions sprites, sets their properties, and draws them in the correct order.\n`background(\"black\");\nvar animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);\nanimalhead_duck1.setAnimation(\"animalhead_duck1\");\nanimalhead_frog_1.setAnimation(\"animalhead_frog_1\");\nanimalhead_frog_1.scale = 0.4;\nanimalhead_duck1.scale = 0.4;\ndrawSprites();`\n\nLines 10-12: Text is added after sprites are drawn.\n`textSize(20);\nfill(\"white\");\ntext(\"Fortnite\", 175, 200);`",
+            "Reason": "The program demonstrates a logical sequence of operations. The background is set first, then sprites are created and their properties are set. The drawSprites() function is called to render the sprites, and finally, the text is added. This sequence ensures that all elements appear as intended, with no overlapping or hiding issues. Decision: Extensive Evidence",
+            "Grade": "Extensive Evidence"
+        },
+        {
+            "Key Concept": "Modularity - Sprites and Sprite Properties",
+            "Observations": "The program creates two sprites and updates properties for both after creation.",
+            "Evidence": "Lines 2-3: Two sprites are created.\n`var animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);`\n\nLines 4-7: Properties of both sprites are updated after creation.\n`animalhead_duck1.setAnimation(\"animalhead_duck1\");\nanimalhead_frog_1.setAnimation(\"animalhead_frog_1\");\nanimalhead_frog_1.scale = 0.4;\nanimalhead_duck1.scale = 0.4;`",
+            "Reason": "The program creates two distinct sprites: animalhead_duck1 and animalhead_frog_1. For both sprites, it sets the animation and scale properties after creation. This meets the criteria for Extensive Evidence as there are at least 2 sprites created, each with at least one property updated after creation. Decision: Extensive Evidence",
+            "Grade": "Extensive Evidence"
+        },
+        {
+            "Key Concept": "Position - Elements and the Coordinate System",
+            "Observations": "The program places two sprites and one line of text using the coordinate system. No shapes are created.",
+            "Evidence": "Lines 2-3: Two sprites are positioned using coordinates.\n`var animalhead_duck1 = createSprite(352, 200);\nvar animalhead_frog_1 = createSprite(46, 200);`\n\nLine 12: One line of text is positioned using coordinates.\n`text(\"Fortnite\", 175, 200);`",
+            "Reason": "The program demonstrates the use of the coordinate system to place elements on the screen. It positions two sprites (animalhead_duck1 and animalhead_frog_1) and one line of text (\"Fortnite\") using x and y coordinates. However, it does not create any shapes using functions like rect, ellipse, circle, quad, or triangle. According to the rubric, for Convincing Evidence, we need at least 1 shape, 2 sprites, and 1 line of text. While the program meets the criteria for sprites and text, it lacks any shapes. Therefore, it falls under the Limited Evidence category. Decision: Limited Evidence",
+            "Grade": "Limited Evidence"
+        }
+    ]
+    yield json.dumps(response_data)
+
+@pytest.fixture
+def lesson_11_response_body(lesson_11_response_json):
+    body_data = {
+        "id": "msg_bdrk_01234567890abcdefghijklm",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20240620",
+        "content": [
+            {
+                "type": "text",
+                "text": lesson_11_response_json
+            }
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 1397,
+            "output_tokens": 972
+        }
+    }
+    yield json.dumps(body_data, indent=2)
+
+
+class TestIntegrationPostAssessment:
+    """ Tests POST to '/assessment' to start an assessment.
+
+    This is an integration test because it tests all the way to the AI API request, rather than just checking what gets passed to Label.
+    """
+
+    def test_succeeds_when_bedrock_returns_valid_response(self, mocker, client, lesson_11_request_data, lesson_11_response_body):
+        # stub the bedrock response
+        response_body = lesson_11_response_body
+        invoke_model_response = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'body': io.StringIO(response_body)}
+        class mock_bedrock_client:
+            def invoke_model(body, modelId, accept, contentType):
+                assert modelId == 'anthropic.claude-3-5-sonnet-20240620-v1:0'
+                assert accept == 'application/json'
+                assert contentType == 'application/json'
+                return invoke_model_response
+        get_bedrock_client_mock = mocker.patch.object(
+            Label,
+            'get_bedrock_client',
+            return_value=mock_bedrock_client
+        )
+
+        # send the flask request
+        request_data = lesson_11_request_data
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string=request_data, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+
+        assert response.status_code == 200
+
+        # check that get_bedrock_client_mock was called
+        get_bedrock_client_mock.assert_called_once()
 
 
 class TestPostTestAssessment:

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -261,7 +261,8 @@ def lesson_11_response_data():
         }
     ]
 
-def get_response_body(response_json):
+def get_bedrock_claude_response_body(response_data):
+    response_json = json.dumps(response_data)
     body_data = {
         "id": "msg_bdrk_01234567890abcdefghijklm",
         "type": "message",
@@ -284,15 +285,13 @@ def get_response_body(response_json):
 
 @pytest.fixture
 def lesson_11_response_body(lesson_11_response_data):
-    response_json = json.dumps(lesson_11_response_data)
-    yield get_response_body(response_json)
+    yield get_bedrock_claude_response_body(lesson_11_response_data)
 
 @pytest.fixture
 def lesson_11_response_body_mismatched(lesson_11_response_data):
     response_data = lesson_11_response_data
     response_data[0]["Key Concept"] = "Bogus Key Concept"
-    response_json = json.dumps(response_data)
-    yield get_response_body(response_json)
+    yield get_bedrock_claude_response_body(response_data)
 
 class TestIntegrationPostAssessment:
     """ Tests POST to '/assessment' to start an assessment.

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -63,47 +63,6 @@ class TestPostAssessment:
         # check that get_bedrock_client_mock was called
         get_bedrock_client_mock.assert_called_once()
 
-    def test_should_return_400_when_no_code(self, client, randomstring):
-        os.environ['AIPROXY_API_KEY'] = 'test_key'
-        response = client.post('/assessment', query_string={
-          "prompt": randomstring(10),
-          "rubric": randomstring(10),
-          "api-key": randomstring(10),
-          "examples": "[]",
-          "model": randomstring(10),
-          "remove-comments": "1",
-          "num-responses": "1",
-          "temperature": "0.2",
-        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-        assert response.status_code == 400
-
-    def test_should_return_400_when_no_prompt(self, client, randomstring):
-        os.environ['AIPROXY_API_KEY'] = 'test_key'
-        response = client.post('/assessment', query_string={
-          "code": randomstring(10),
-          "rubric": randomstring(10),
-          "api-key": randomstring(10),
-          "examples": "[]",
-          "model": randomstring(10),
-          "remove-comments": "1",
-          "num-responses": "1",
-          "temperature": "0.2",
-        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-        assert response.status_code == 400
-
-    def test_should_return_400_when_no_rubric(self, client, randomstring):
-        os.environ['AIPROXY_API_KEY'] = 'test_key'
-        response = client.post('/assessment', query_string={
-          "code": randomstring(10),
-          "prompt": randomstring(10),
-          "api-key": randomstring(10),
-          "examples": "[]",
-          "model": randomstring(10),
-          "remove-comments": "1",
-          "num-responses": "1",
-          "temperature": "0.2",
-        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-        assert response.status_code == 400
 
     def test_should_return_413_on_request_too_large_error(self, mocker, client, randomstring, lesson_11_rubric, bedrock_claude_model, lesson_11_response_body_too_large):
         # stub the bedrock response
@@ -135,42 +94,84 @@ class TestPostAssessment:
 
         get_bedrock_client_mock.assert_called_once()
 
-    def test_should_return_400_when_passing_not_a_number_to_num_responses(self, client, randomstring):
-        os.environ['AIPROXY_API_KEY'] = 'test_key'
-        response = client.post('/assessment', query_string={
-          "code": randomstring(10),
-          "prompt": randomstring(10),
-          "rubric": randomstring(10),
-          "api-key": randomstring(10),
-          "examples": "[]",
-          "model": randomstring(10),
-          "remove-comments": "1",
-          "num-responses": "x",
-          "temperature": "0.2",
-        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-        assert response.status_code == 400
-
-    def test_should_return_400_when_passing_not_a_number_to_temperature(self, client, randomstring):
-        os.environ['AIPROXY_API_KEY'] = 'test_key'
-        response = client.post('/assessment', query_string={
-          "code": randomstring(10),
-          "prompt": randomstring(10),
-          "rubric": randomstring(10),
-          "api-key": randomstring(10),
-          "examples": "[]",
-          "model": randomstring(10),
-          "remove-comments": "1",
-          "num-responses": "2",
-          "temperature": "x",
-        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
-        assert response.status_code == 400
-
 
 class TestPostAssessmentUnitTests:
     """ Tests POST to '/assessment' to start an assessment.
 
     These tests stub out the Label class to test the API endpoint in isolation.
     """
+
+    def test_should_return_400_when_no_code(self, client, randomstring):
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string={
+            "prompt": randomstring(10),
+            "rubric": randomstring(10),
+            "api-key": randomstring(10),
+            "examples": "[]",
+            "model": randomstring(10),
+            "remove-comments": "1",
+            "num-responses": "1",
+            "temperature": "0.2",
+        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+        assert response.status_code == 400
+
+    def test_should_return_400_when_no_prompt(self, client, randomstring):
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string={
+            "code": randomstring(10),
+            "rubric": randomstring(10),
+            "api-key": randomstring(10),
+            "examples": "[]",
+            "model": randomstring(10),
+            "remove-comments": "1",
+            "num-responses": "1",
+            "temperature": "0.2",
+        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+        assert response.status_code == 400
+
+    def test_should_return_400_when_no_rubric(self, client, randomstring):
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string={
+            "code": randomstring(10),
+            "prompt": randomstring(10),
+            "api-key": randomstring(10),
+            "examples": "[]",
+            "model": randomstring(10),
+            "remove-comments": "1",
+            "num-responses": "1",
+            "temperature": "0.2",
+        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+        assert response.status_code == 400
+
+    def test_should_return_400_when_passing_not_a_number_to_num_responses(self, client, randomstring):
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string={
+            "code": randomstring(10),
+            "prompt": randomstring(10),
+            "rubric": randomstring(10),
+            "api-key": randomstring(10),
+            "examples": "[]",
+            "model": randomstring(10),
+            "remove-comments": "1",
+            "num-responses": "x",
+            "temperature": "0.2",
+        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+        assert response.status_code == 400
+
+    def test_should_return_400_when_passing_not_a_number_to_temperature(self, client, randomstring):
+        os.environ['AIPROXY_API_KEY'] = 'test_key'
+        response = client.post('/assessment', query_string={
+            "code": randomstring(10),
+            "prompt": randomstring(10),
+            "rubric": randomstring(10),
+            "api-key": randomstring(10),
+            "examples": "[]",
+            "model": randomstring(10),
+            "remove-comments": "1",
+            "num-responses": "2",
+            "temperature": "x",
+        }, headers={"Content-type": "application/x-www-form-urlencoded", "Authorization": "test_key"})
+        assert response.status_code == 400
 
     def test_should_return_400_when_the_label_function_does_not_return_data(self, mocker, client, randomstring):
         label_mock = mocker.patch('lib.assessment.assess.validate_and_label')

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -261,16 +261,6 @@ def lesson_11_response_data():
         }
     ]
 
-@pytest.fixture
-def lesson_11_response_json(lesson_11_response_data):
-    yield json.dumps(lesson_11_response_data)
-
-@pytest.fixture
-def lesson_11_response_json_mismatched(lesson_11_response_data):
-    response_data = lesson_11_response_data
-    response_data[0]["Key Concept"] = "Bogus Key Concept"
-    yield json.dumps(response_data)
-
 def get_response_body(response_json):
     body_data = {
         "id": "msg_bdrk_01234567890abcdefghijklm",
@@ -293,12 +283,16 @@ def get_response_body(response_json):
     return json.dumps(body_data, indent=2)
 
 @pytest.fixture
-def lesson_11_response_body(lesson_11_response_json):
-    yield get_response_body(lesson_11_response_json)
+def lesson_11_response_body(lesson_11_response_data):
+    response_json = json.dumps(lesson_11_response_data)
+    yield get_response_body(response_json)
 
 @pytest.fixture
-def lesson_11_response_body_mismatched(lesson_11_response_json_mismatched):
-    yield get_response_body(lesson_11_response_json_mismatched)
+def lesson_11_response_body_mismatched(lesson_11_response_data):
+    response_data = lesson_11_response_data
+    response_data[0]["Key Concept"] = "Bogus Key Concept"
+    response_json = json.dumps(response_data)
+    yield get_response_body(response_json)
 
 class TestIntegrationPostAssessment:
     """ Tests POST to '/assessment' to start an assessment.


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/AITT-497. This PR adds integration testing to aiproxy, which differs from the existing unit tests because it attempts to cover the entire codepath for the assessment route (which we use to evaluate student work in production), stubbing out only the AI API request.
