### PR TITLE
adds L7 to config and ability to autogenerate labels

### DIFF
--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -19,7 +19,7 @@ SUPPORTED_MODELS = [
     'gpt-4-turbo-2024-04-09'
 ]
 DEFAULT_MODEL = 'bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0'
-LESSONS = ['csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
+LESSONS = ['csd3-2023-L7','csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
 DEFAULT_DATASET_NAME = 'contractor-grades-batch-1-fall-2023'
 
 OPENAI_API_TIMEOUT = 150

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -16,6 +16,7 @@ import logging
 import pprint
 import boto3
 import subprocess
+import datetime
 
 from sklearn.metrics import accuracy_score, confusion_matrix
 from collections import defaultdict
@@ -70,6 +71,7 @@ def command_line_options():
                         help='Generate confidence levels for each learning goal')
     parser.add_argument('-w', '--workers', type=int, default=7,
                         help='Number of workers to use for processing. Defaults to 7 workers.')
+    parser.add_argument('--new-labels', action='store_true', help='Generate new labels for the dataset using LLM')
 
     args = parser.parse_args()
 
@@ -189,8 +191,7 @@ def validate_rubrics(actual_labels, standard_rubric):
     standard_concepts = sorted([rubric_dict["Key Concept"] for rubric_dict in standard_rubric_dicts])
     if standard_concepts != actual_concepts:
         raise Exception(f"standard concepts do not match actual concepts:\n{standard_concepts}\n{actual_concepts}")
-
-
+    
 def validate_students(student_files, actual_labels):
     actual_students = sorted(actual_labels.keys())
     predicted_students = sorted([os.path.splitext(os.path.basename(student_file))[0] for student_file in student_files])
@@ -199,6 +200,24 @@ def validate_students(student_files, actual_labels):
     if unexpected_students:
         raise Exception(f"unexpected students: {unexpected_students}")
 
+def generate_new_labels_file(standard_rubric, predicted_labels, dataset_lesson_path):
+    standard_rubric_filelike = io.StringIO(standard_rubric)  # convert string to file-like object
+    standard_rubric_dicts = list(csv.DictReader(standard_rubric_filelike))
+    standard_concepts = sorted([rubric_dict["Key Concept"] for rubric_dict in standard_rubric_dicts])
+    with open(f'{dataset_lesson_path}/{datetime.datetime.now()}-new-labels.csv', 'w') as f:
+        writer = csv.writer(f, delimiter=',')
+        header = ["student"]
+        for concept in standard_concepts:
+            header.append(concept)
+        writer.writerow(header)
+        students = predicted_labels.keys()
+        for student in students:
+            row = [student]
+            for label in predicted_labels[student]:
+                row.append(label["Label"])
+            writer.writerow(row)
+
+        
 
 def compute_accuracy(actual_labels, predicted_labels, is_pass_fail):
     actual_by_criteria = defaultdict(list)
@@ -336,14 +355,16 @@ def main():
         response_type = params.get('response-type', 'tsv')
         prompt, standard_rubric = read_inputs(prompt_file, standard_rubric_file, params_lesson_prefix)
         student_files = get_student_files(options.max_num_students, dataset_lesson_prefix, student_ids=options.student_ids)
-        if os.path.exists(os.path.join(dataset_lesson_prefix, actual_labels_file_old)):
-            actual_labels = get_actual_labels(actual_labels_file_old, dataset_lesson_prefix)
-        else:
-            actual_labels = get_actual_labels(actual_labels_file, dataset_lesson_prefix)
+        if not options.new_labels:
+            if os.path.exists(os.path.join(dataset_lesson_prefix, actual_labels_file_old)):
+                actual_labels = get_actual_labels(actual_labels_file_old, dataset_lesson_prefix)
+            else:
+                actual_labels = get_actual_labels(actual_labels_file, dataset_lesson_prefix)
         examples = get_examples(params_lesson_prefix, response_type)
+        if not options.new_labels:
+            validate_rubrics(actual_labels, standard_rubric)
+            validate_students(student_files, actual_labels)
 
-        validate_rubrics(actual_labels, standard_rubric)
-        validate_students(student_files, actual_labels)
         rubric = standard_rubric
 
         # set up output and cache directories
@@ -360,6 +381,9 @@ def main():
         errors = [student_id for student_id, labels in predicted_labels if not labels]
         # predicted_labels contains metadata and data (labels), we care about the data key
         predicted_labels = {student_id: labels['data'] for student_id, labels in predicted_labels if labels}
+        if options.new_labels:
+            generate_new_labels_file(standard_rubric, predicted_labels, dataset_lesson_prefix)
+            return True
 
         for is_pass_fail in [True, False]:
             output_filename = 'report-pass-fail.html' if is_pass_fail else 'report-exact-match.html'


### PR DESCRIPTION
## Description
Adds lesson 7 to the config
Also adds a new argument and function to rubric_tester to allow for auto-generation of label files via LLM.
## Links
<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->
<!--
- spec: []()
- jira ticket: []()
-->
## Testing story
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
  If any experiments on cdo-ai S3 are relevant to your changes, list them here
-->
## Accuracy
<!--
  Does this code change affect accuracy against the dev set? Include before/ after accuracy changes. For any changes that should not affect accuracy, explain why.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
## API Changes
<!-- 
  Does this code change the API?
-->
## Follow-up work
<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work. Also list any corresponding changes that need to be made in the cdo-ai S3 releases or in the CDO repo.
-->
## PR Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [ ] Accuracy against the dev set has been retested
- [ ] Changes in accuracy have been communicated
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
