### PR TITLE
Updates to sanitize the Evidence field.

### DIFF
--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -32,9 +32,6 @@ class Label:
     _bedrock_client = None
     _bedrock_lock = Lock()
 
-    def __init__(self):
-        pass
-
     # Check to ensure that student project is not blank. Assessment is statically generated for blank code.
     def test_for_blank_code(self, rubric, student_code, student_id):
         rubric_key_concepts = list(set(row['Key Concept'] for row in csv.DictReader(rubric.splitlines())))
@@ -310,6 +307,9 @@ class Label:
                 if row["Key Concept"] in code_feature_extractor:
                     response["data"][i] = [cfe_row for cfe_row in cfe_results["data"] if cfe_row["Key Concept"] == row["Key Concept"]][0]
 
+        # Sanitize Evidence
+        self._sanitize_result(response['data'])
+
         # only write to cache if the response is valid
         if write_cached and ai_result:
             with open(os.path.join(cache_prefix, f"cached_responses/{student_id}.json"), 'w+') as f:
@@ -499,6 +499,29 @@ class Label:
             if "Grade" in row.keys():
                 row['Label'] = row['Grade']
                 del row['Grade']
+
+    def _sanitize_result(self, data):
+        for kc in data:
+            if not 'Evidence' in kc:
+                continue
+
+            # Ensure all Evidence is a string delimited by spaces (and not newlines)
+            if isinstance(kc.get('Evidence'), list):
+                # The CFE might return a list here. We want a single string
+                kc['Evidence'] = ' '.join(kc['Evidence'])
+
+            if not isinstance(kc.get('Evidence'), str):
+                # Ensure that the Evidence field is a string in some way before continuing
+                kc['Evidence'] = str(kc['Evidence'])
+
+            # Get rid of newlines
+            kc['Evidence'] = kc['Evidence'].replace("\n", " ")
+
+            # Convert "Lines x, y, z:" into "Lines x-z:"
+            # Claude in particular likes to occasionally report evidence this way
+            for match in re.finditer(r"Lines? (?P<start>\d+), (\d+)*, (?P<end>\d+)", kc['Evidence']):
+                # Match the fully matched string with the first number and last number as a range
+                kc['Evidence'] = kc['Evidence'].replace(match[0], f"Lines {match['start']}-{match['end']}")
 
     def _validate_server_response(self, response_data, rubric):
         expected_columns = ["Key Concept", "Observations", "Label", "Reason"]

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -17,6 +17,7 @@ import pprint
 import boto3
 import subprocess
 import datetime
+import shutil
 
 from sklearn.metrics import accuracy_score, confusion_matrix
 from collections import defaultdict
@@ -367,7 +368,7 @@ def main():
             for file in glob.glob(f'{os.path.join(params_lesson_prefix, cache_dir_name)}/*'):
                 os.remove(file)
 
-        # call label function to either call openAI or read from cache
+        # call label function to either call the AI agent or read from cache
         with concurrent.futures.ThreadPoolExecutor(max_workers=options.workers) as executor:
             predicted_labels = list(executor.map(lambda student_file: read_and_label_student_work(prompt, rubric, student_file, examples, options, params, params_lesson_prefix, response_type), student_files))
 
@@ -435,7 +436,7 @@ def main():
                         accuracy_failures[lesson]['key_concepts'][key_concept]['accuracy_score'] = accuracy_by_criteria[key_concept]
                         accuracy_failures[lesson]['key_concepts'][key_concept]['threshold'] = accuracy_thresholds[lesson]['key_concepts'][key_concept]
 
-            if not is_pass_fail:
+            if not is_pass_fail and shutil.which("open") is not None:
                 os.system(f"open {output_file}")
 
             if options.generate_confidence:


### PR DESCRIPTION
## Description

Ensures the following is true for the "`Evidence`" field:

* There are no newlines (these break some of the behavior in the frontend to determine each piece of evidence)
* There are no lists of lines ("Lines x, y, z" for instance. We want to always produce some form of "Lines x-z")
* CFE results produce a conforming string. (CFE results in a list which is serialized into the evidence field.)

## Links

- jira ticket: [AITT-735](https://codedotorg.atlassian.net/browse/AITT-735)

## Testing story

Retrieved strings from broken evidence fields on production.

Reproduced the behavior.

Wedged those and my own non-conforming strings into the path of these code changes. Stored them in LearningGoalAiEvaluation records on the code-dot-org side and saw them successfully render.

Ran a few accuracy report experiments and saw no further non-conforming evidence fields.

Before:

![image](https://github.com/user-attachments/assets/d2eccef1-3796-48ab-affa-2149bd53f3dd)

After:

![image](https://github.com/user-attachments/assets/abb21b0f-bb27-4422-bcd6-0b1c25ea0eec)

After replacing newlines with spaces (Before it gave up and rendered the Observations column):

![image](https://github.com/user-attachments/assets/2b1b71a5-64b0-4a28-8b2a-862f0ef7a122)

## Accuracy

N/A

## API Changes

Enforces that "evidence" is always a string.

## PR Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [ ] Accuracy against the dev set has been retested
- [ ] Changes in accuracy have been communicated
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
