### PR TITLE
Fixes issues resulting from the AI reporting back triple backticks.

### DIFF
--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -517,6 +517,9 @@ class Label:
             # Get rid of newlines
             kc['Evidence'] = kc['Evidence'].replace("\n", " ")
 
+            # Get rid of multiline code blocks (``` -> `)
+            kc['Evidence'] = kc['Evidence'].replace("```", "`")
+
             # Convert "Lines x, y, z:" into "Lines x-z:"
             # Claude in particular likes to occasionally report evidence this way
             for match in re.finditer(r"Lines? (?P<start>\d+), (\d+)*, (?P<end>\d+)", kc['Evidence']):


### PR DESCRIPTION
A quick follow-up to an earlier PR to address backticks in evidence strings (\```some code```)

Implemented test first with a red-then-green result.

## PR Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [ ] Accuracy against the dev set has been retested
- [ ] Changes in accuracy have been communicated
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
