### PR TITLE
increase waitress web server connection limit to 200

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY ./lib /app/lib
 COPY ./src /app/src
 
 EXPOSE 80
-CMD ["waitress-serve", "--host=0.0.0.0", "--port=80", "--call", "src:create_app"]
+CMD ["waitress-serve", "--host=0.0.0.0", "--port=80", "--connection-limit=200", "--call", "src:create_app"]


### PR DESCRIPTION
See [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1730926430077059?thread_ts=1730923008.375129&cid=C0T0PNTM3). 

aiproxy uses a web server called waitress. waitress has a default limit of 100 incoming network connections. now that we have 150 delayed job workers, we're occasionally exceeding this limit. the solution is to increase the max number of connections (see [docs](https://docs.pylonsproject.org/projects/waitress/en/latest/runner.html#:~:text=%2D%2Dconnection%2Dlimit%3DINT)).

## Testing story

* ran `docker compose build && docker compose up` locally, and verified that it can handle requests generated by my local server. this just confirms I didn't break anything so badly that the server can't start up.
* temporarily lowered the limit to 3 and sent a request from my local dashboard server. got the following message confirming the setting is being picked up: `waitress:total open connections reached the connection limit, no longer accepting new connections`