### PR TITLE
stop recording cfe features into observations field of aiproxy response

### DIFF
--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -79,10 +79,11 @@ class Label:
             dt.assess(cfe.features, learning_goal, lesson)
             results["data"].append({"Label": dt.assessment,
                                     "Key Concept": learning_goal["Key Concept"],
-                                    "Observations": cfe.features,
+                                    "Observations": '',
                                     "Reason": learning_goal[dt.assessment] if dt.assessment else '',
                                     "Evidence": dt.evidence,
                                         })
+            logging.debug(f"Key Concept: {learning_goal['Key Concept']} CFE features: {cfe.features}")
 
         return results
 


### PR DESCRIPTION
Finishes [AITT-872: EvaluateRubricJob errors: ValueTooLong for observations column](https://codedotorg.atlassian.net/browse/AITT-872). 

The observations column has a size limit of 65535. In the production database, there were many observation column values close to this limit ([example](https://docs.google.com/document/d/1NGq0XyN54anECAhsrdt0FXLPekghO5A36FSAuOJxdpo/edit?tab=t.0#heading=h.kxugsy7pgmvl)). This format was confirmed to be output from the code feature extractor which is needed for debugging purposes only. While the observations column is sometimes used as part of the evidence feature, it is not useful in this format. Therefore the proposed solution is to stop writing this debug info to the database. 

The `logging.debug` statement will not write anywhere by default, but we could turn on logging to cloudfront logs or in local development as needed.

While we could do extra work to keep logging this data to the database without sending it to the client, this would require a bit more work which doesn't seem worth it given that we can just as easily turn on debug logging to cloudwatch as needed.

## Testing story

verified end-to-end that evidence is still working for CFE-enabled learning goal `Lesson 11` - `Position - Elements and the Coordinate System`
![Screenshot 2024-11-20 at 3 45 25 PM](https://github.com/user-attachments/assets/ca271946-234d-49d6-a26a-07c111041781)


