### PR TITLE
gracefully handle newlines in ai assessment response json

### DIFF
--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -439,7 +439,7 @@ class Label:
         json_text = match.group(1)
 
         try:
-            data = json.loads(json_text)
+            data = json.loads(json_text, strict=False)
         except json.JSONDecodeError as e:
             if finish_reason == 'length' or finish_reason == 'max_tokens':
                 raise RequestTooLargeError(f"{student_id}: JSON decoding error")

--- a/tests/unit/assessment/conftest.py
+++ b/tests/unit/assessment/conftest.py
@@ -270,7 +270,7 @@ def openai_gpt_response(randomstring):
             'Key Concept': key_concept,
             'Observations': randomstring(10),
             'Grade': label,
-            'Reason': randomstring(10)
+            'Reason': f"stub-reason-{randomstring(10)}"
         }
 
     def gen_tabular_response(choice_data, output_type):

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -181,7 +181,7 @@ class TestGetResponseDataIfValid:
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
-    def test_should_work_for_json_response_type(self, label, rubric, student_id, openai_gpt_response, output_type='json'):
+    def test_can_parse_json_response_type(self, label, rubric, student_id, openai_gpt_response, output_type='json'):
         ai_response = openai_gpt_response(rubric, num_responses=1, output_type=output_type)
         choice = ai_response['choices'][0]
 
@@ -192,6 +192,19 @@ class TestGetResponseDataIfValid:
         assert result is not None
         assert len(result) == len(parsed_rubric)
 
+    def test_can_parse_json_strings_containing_newlines(self, label, rubric, student_id, openai_gpt_response, output_type='json'):
+        ai_response = openai_gpt_response(rubric, num_responses=1, output_type=output_type)
+        choice = ai_response['choices'][0]
+
+        # add newline inside "Reason" field
+        choice['message']['content'] = choice['message']['content'].replace('stub-reason-', 'stub-reason\n')
+
+        parsed_rubric = list(csv.DictReader(rubric.splitlines()))
+
+        # It should parse them out to get the same number of rows as the rubric
+        result = label.get_response_data_if_valid(choice, rubric, student_id, response_type='json')
+        assert result is not None
+        assert len(result) == len(parsed_rubric)
 
     @pytest.mark.parametrize("output_type", ['tsv', 'csv', 'markdown'])
     def test_should_work_for_different_output_types_with_leading_text(self, label, rubric, student_id, openai_gpt_response, output_type):


### PR DESCRIPTION
Starts [AITT-810: EvaluateRubricJob runtime error parsing evidence json](https://codedotorg.atlassian.net/browse/AITT-810). There are many different variations of errors in the honeybadger issue, but most of them have to do with failing to parse newline characters within strings in the JSON within the ai response body.

This PR makes a first pass at fixing these issues by updating the `json.loads` call to allow newline characters within strings. given the [alternative of properly escaping these characters](https://stackoverflow.com/questions/9295439/python-json-loads-fails-with-valueerror-invalid-control-character-at-line-1-c/9295597#9295597), it seems easier to [set strict to false](https://docs.python.org/3/library/json.html#:~:text=If%20strict%20is%20false).

note that https://github.com/code-dot-org/aiproxy/pull/97 attempts to remove newline characters from the evidence field, but this happens too late because if they were not properly escaped then JSON parsing will already have failed.

### alternative

if we're sure we never want any newlines, we could alternately strip them instead of allowing them. however if it will make certain fields like Observations more readable then I'm inclined to allow them, but I could be convinced otherwise.

### examples

Evidence containing newlines:
* honeybadger: https://app.honeybadger.io/projects/3240/faults/110378395/01JD88T6AKD69XF94RZVFAZRBH
* snippet of raw ai response from the new `bedrock-model-invocation` log group in cloudwatch:
```
    "output": {
        "outputContentType": "application/json",
        "outputBodyJson": {
            "id": "msg_bdrk_01PbW6SdhXWYK5AqjdbdQt1Y",
            "type": "message",
            "role": "assistant",
            "model": "claude-3-5-sonnet-20240620",
            "content": [
                {
                    "type": "text",
                    "text": "```json\n[\n  {\n    \"Key Concept\": \"Modularity - Multiple Sprites\",\n    \"Observations\": \"8 sprites created: l, s, s1, s2, s3, p2, t, p1. 4 sprites (s, s1, s2, s3) have properties updated in the draw loop.\",\n    \"Evidence\": \"Lines 6-13: `var l = createSprite(60, 80);\nvar s = createSprite(randomNumber(1, 100), y);\nvar s1 = createSprite(randomNumber(101, 200), y);\n...
```
newlines seem to only be a problem when they appear within a string: 
```
\"Evidence\": \"Lines 6-13: `var l = createSprite(60, 80);\nvar...
                                                          ^^
```

Reason containing newlines:
* honeybadger: https://app.honeybadger.io/projects/3240/faults/110378395/01JD86YK0S1XJTHW2PDRTM9PYC

## Testing story

* verified that the new unit test fails without the code change