### PR TITLE
Update to Claude 4.5

### DIFF
--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -7,6 +7,7 @@ SUPPORTED_MODELS = [
     'bedrock.anthropic.claude-v2',
     'bedrock.anthropic.claude-3-sonnet-20240229-v1:0',
     'bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0',
+    'bedrock.anthropic.claude-sonnet-4-5-20250929-v1:0',
     'bedrock.meta.llama2-13b-chat-v1',
     'bedrock.meta.llama2-70b-chat-v1',
     'gpt-3.5-turbo-0125',
@@ -18,7 +19,7 @@ SUPPORTED_MODELS = [
     'gpt-4-0125-preview',
     'gpt-4-turbo-2024-04-09'
 ]
-DEFAULT_MODEL = 'bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0'
+DEFAULT_MODEL = 'bedrock.anthropic.claude-sonnet-4-5-20250929-v1:0'
 LESSONS = ['csd3-2023-L7','csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
 DEFAULT_DATASET_NAME = 'contractor-grades-batch-1-fall-2023'
 


### PR DESCRIPTION
## Description
Claude 3.5 was deprecated on Amazon Bedrock, which has caused AI rubric evaluation jobs to fail. This updates our models to use Claude 4.5 to resolve this issue.
## Links
[Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1775167076660509)
## Testing story
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
  If any experiments on cdo-ai S3 are relevant to your changes, list them here
-->
## Accuracy
Will be running accuracy tests after this update is merged. The priority right now is to get the tool working again.
## API Changes
<!-- 
  Does this code change the API?
-->
## Follow-up work
The following work has been done which is linked to this PR:
1. Created a new release in S3 with the model updated in the params files (2026-04-06-claude-4-update)
2. Created a [PR for the main CDO repository](https://github.com/code-dot-org/code-dot-org/pull/71970) that updates the S3 location
## PR Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [ ] Accuracy against the dev set has been retested
- [ ] Changes in accuracy have been communicated
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
