### PR TITLE
Use inference profiles for calling bedrock models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 RUN apt-get update && \
-    apt-get install -y curl unzip sudo && \
+    apt-get install -y curl unzip gosu && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
-    sudo ./aws/install
+    gosu root ./aws/install
 
 COPY ./tests /app/tests
 COPY ./lib /app/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR /app
 COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update && \
+    apt-get install -y curl unzip sudo && \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    sudo ./aws/install
 
 COPY ./tests /app/tests
 COPY ./lib /app/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 RUN apt-get update && \
-    apt-get install -y curl unzip gosu --no-install-recommends && \
+    apt-get install -y curl=8.14.1-2+deb13u2 unzip=6.0-29 gosu=1.17-3+b4 --no-install-recommends && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     gosu root ./aws/install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 RUN apt-get update && \
-    apt-get install -y curl unzip gosu && \
+    apt-get install -y curl unzip gosu --no-install-recommends && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
-    gosu root ./aws/install
+    gosu root ./aws/install && \
+    rm -rf /var/lib/apt/lists
 
 COPY ./tests /app/tests
 COPY ./lib /app/lib

--- a/bin/assessment-test.rb
+++ b/bin/assessment-test.rb
@@ -19,7 +19,7 @@ example_rubric = File.read('tests/data/example.tsv')
 examples = [[example_code, example_rubric]]
 
 form_data = [
-  ['model', 'gpt-4-0613'],
+  ['model', 'bedrock.us.anthropic.claude-sonnet-4-5-20250929-v1:0'],
   ['code', code],
   ['prompt', prompt],
   ['rubric', rubric],

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -179,10 +179,10 @@ Resources:
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
                   - arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0
-                  - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                  - !Sub "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
                 Condition:
                   StringLike:
-                    - bedrock:InferenceProfileArn: !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                    - bedrock:InferenceProfileArn: !Sub "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
   ECSServiceAutoScalingRole:
     Type: AWS::IAM::Role

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -179,10 +179,10 @@ Resources:
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
                   - arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0
-                  - !Sub arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+                  - !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
                 Condition:
                   StringLike:
-                    - bedrock:InferenceProfileArn: !Sub arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+                    - bedrock:InferenceProfileArn: !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
   ECSServiceAutoScalingRole:
     Type: AWS::IAM::Role

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -165,7 +165,7 @@ Resources:
               - sts:AssumeRole
       Policies:
         # TODO: This is too broad, it gives access to all aiproxy environments' api keys
-        # Fix this be creating the policy in the aiproxy stack (blocked by cicd role permissions)
+        # Fix this by creating the policy in the aiproxy stack (blocked by cicd role permissions)
         - PolicyName: ECSTaskBedrockPolicy
           PolicyDocument:
             Version: "2012-10-17"
@@ -173,10 +173,16 @@ Resources:
               - Effect: Allow
                 Action:
                   - bedrock:InvokeModel
+                  - bedrock:GetInferenceProfile
                 Resource:
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
+                  - arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0
+                  - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                Conition:
+                  StringLike:
+                    - bedrock:InferenceProfileArn: !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
   ECSServiceAutoScalingRole:
     Type: AWS::IAM::Role

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -180,7 +180,7 @@ Resources:
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
                   - arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0
                   - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
-                Conition:
+                Condition:
                   StringLike:
                     - bedrock:InferenceProfileArn: !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -179,10 +179,10 @@ Resources:
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
                   - arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0
-                  - !Sub "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                  - !Sub arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
                 Condition:
                   StringLike:
-                    - bedrock:InferenceProfileArn: !Sub "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                    - bedrock:InferenceProfileArn: !Sub arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
   ECSServiceAutoScalingRole:
     Type: AWS::IAM::Role

--- a/cicd/1-setup/cicd-dependencies.template.yml
+++ b/cicd/1-setup/cicd-dependencies.template.yml
@@ -179,10 +179,10 @@ Resources:
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-sonnet-20240229-v1:0
                   - arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
                   - arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0
-                  - !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+                  - !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
                 Condition:
                   StringLike:
-                    - bedrock:InferenceProfileArn: !Sub arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0
+                    bedrock:InferenceProfileArn: !Sub "arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
   ECSServiceAutoScalingRole:
     Type: AWS::IAM::Role

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   python-proxy:
     build: .

--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -7,6 +7,7 @@ SUPPORTED_MODELS = [
     'bedrock.anthropic.claude-v2',
     'bedrock.anthropic.claude-3-sonnet-20240229-v1:0',
     'bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0',
+    'bedrock.anthropic.claude-sonnet-4-5-20250929-v1:0',
     'bedrock.meta.llama2-13b-chat-v1',
     'bedrock.meta.llama2-70b-chat-v1',
     'gpt-3.5-turbo-0125',
@@ -18,7 +19,7 @@ SUPPORTED_MODELS = [
     'gpt-4-0125-preview',
     'gpt-4-turbo-2024-04-09'
 ]
-DEFAULT_MODEL = 'bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0'
+DEFAULT_MODEL = 'bedrock.anthropic.claude-sonnet-4-5-20250929-v1:0'
 LESSONS = ['csd3-2023-L7','csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
 DEFAULT_DATASET_NAME = 'contractor-grades-batch-1-fall-2023'
 

--- a/lib/assessment/config.py
+++ b/lib/assessment/config.py
@@ -7,7 +7,7 @@ SUPPORTED_MODELS = [
     'bedrock.anthropic.claude-v2',
     'bedrock.anthropic.claude-3-sonnet-20240229-v1:0',
     'bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0',
-    'bedrock.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    'bedrock.us.anthropic.claude-sonnet-4-5-20250929-v1:0',
     'bedrock.meta.llama2-13b-chat-v1',
     'bedrock.meta.llama2-70b-chat-v1',
     'gpt-3.5-turbo-0125',
@@ -19,7 +19,7 @@ SUPPORTED_MODELS = [
     'gpt-4-0125-preview',
     'gpt-4-turbo-2024-04-09'
 ]
-DEFAULT_MODEL = 'bedrock.anthropic.claude-sonnet-4-5-20250929-v1:0'
+DEFAULT_MODEL = 'bedrock.us.anthropic.claude-sonnet-4-5-20250929-v1:0'
 LESSONS = ['csd3-2023-L7','csd3-2023-L11','csd3-2023-L14','csd3-2023-L18','csd3-2023-L21','csd3-2023-L24','csd3-2023-L28']
 DEFAULT_DATASET_NAME = 'contractor-grades-batch-1-fall-2023'
 

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -105,11 +105,11 @@ class Label:
 
         bedrock = self.get_bedrock_client(student_id)
 
-        # strip 'bedrock.' from the model name
-        bedrock_model = f'arn:aws:bedrock:{aws_region}:{aws_account.strip()}:inference-profile/{llm_model[8:]}'
-        logging.log(100, bedrock_model)
-        # if not bedrock_model.startswith("anthropic."):
-        #     raise Exception(f"Error parsing llm_model: {llm_model} bedrock_model: {bedrock_model}")
+        # Update claude 4+ to use inference profiles. Otherwise, claude 3 just needs 'bedrock.' stripped from the beginning
+        if not "claude-3" in llm_model:
+            bedrock_model = f'arn:aws:bedrock:{aws_region}:{aws_account.strip()}:inference-profile/{llm_model[8:]}'
+        else:
+            bedrock_model = llm_model[8:]
 
         anthropic_prompt = self.compute_anthropic_prompt(prompt, rubric, student_code, examples=examples)
         if "claude" in bedrock_model:
@@ -204,10 +204,12 @@ class Label:
                     cls._bedrock_client = boto3.client(service_name='bedrock-runtime', config=bedrock_config)
         return cls._bedrock_client
     
+    # When using inference profiles, we need to access the AWS account ID
     def get_aws_account(cls):
         if cls._aws_account is None:
-            result = subprocess.run('aws sts get-caller-identity --query Account --output text', shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            cls._aws_account = result.stdout
+            with cls._bedrock_lock:
+                result = subprocess.run('aws sts get-caller-identity --query Account --output text', shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                cls._aws_account = result.stdout
         return cls._aws_account
 
     def openai_label_student_work(self, prompt, rubric, student_code, student_id, examples=[], num_responses=0, temperature=0.0, llm_model="", response_type='tsv'):

--- a/lib/assessment/label.py
+++ b/lib/assessment/label.py
@@ -8,6 +8,7 @@ import logging
 import boto3
 from botocore.config import Config
 from threading import Lock
+import subprocess
 
 from typing import List, Dict, Any
 from lib.assessment.config import VALID_LABELS, OPENAI_API_TIMEOUT
@@ -31,6 +32,7 @@ class BedrockServerError(Exception):
 class Label:
     _bedrock_client = None
     _bedrock_lock = Lock()
+    _aws_account = None
 
     # Check to ensure that student project is not blank. Assessment is statically generated for blank code.
     def test_for_blank_code(self, rubric, student_code, student_id):
@@ -92,21 +94,25 @@ class Label:
             return self.openai_label_student_work(prompt, rubric, student_code, student_id, examples=examples, num_responses=num_responses, temperature=temperature, llm_model=llm_model, response_type=response_type)
         elif llm_model.startswith("bedrock.meta"):
             return self.bedrock_meta_label_student_work(prompt, rubric, student_code, student_id, examples=examples, num_responses=num_responses, temperature=temperature, llm_model=llm_model)
-        elif llm_model.startswith("bedrock.anthropic"):
+        elif llm_model.startswith("bedrock.anthropic") or llm_model.startswith("bedrock.us.anthropic"):
             return self.bedrock_anthropic_label_student_work(prompt, rubric, student_code, student_id, examples=examples, num_responses=num_responses, temperature=temperature, llm_model=llm_model)
         else:
             raise Exception("Unknown model: {}".format(llm_model))
 
     def bedrock_anthropic_label_student_work(self, prompt, rubric, student_code, student_id, examples=[], num_responses=0, temperature=0.0, llm_model=""):
+        aws_account = self.get_aws_account()
+        aws_region  = 'us-east-1'
+
         bedrock = self.get_bedrock_client(student_id)
 
         # strip 'bedrock.' from the model name
-        bedrock_model = llm_model[8:]
-        if not bedrock_model.startswith("anthropic."):
-            raise Exception(f"Error parsing llm_model: {llm_model} bedrock_model: {bedrock_model}")
+        bedrock_model = f'arn:aws:bedrock:{aws_region}:{aws_account.strip()}:inference-profile/{llm_model[8:]}'
+        logging.log(100, bedrock_model)
+        # if not bedrock_model.startswith("anthropic."):
+        #     raise Exception(f"Error parsing llm_model: {llm_model} bedrock_model: {bedrock_model}")
 
         anthropic_prompt = self.compute_anthropic_prompt(prompt, rubric, student_code, examples=examples)
-        if "claude-3" in bedrock_model:
+        if "claude" in bedrock_model:
             body = json.dumps({"anthropic_version": "bedrock-2023-05-31",
                                "max_tokens": 4096,
                                "messages": [{"role": "user",
@@ -197,6 +203,12 @@ class Label:
                     bedrock_config = Config(connect_timeout=150, read_timeout=150, retries={'max_attempts': 2})
                     cls._bedrock_client = boto3.client(service_name='bedrock-runtime', config=bedrock_config)
         return cls._bedrock_client
+    
+    def get_aws_account(cls):
+        if cls._aws_account is None:
+            result = subprocess.run('aws sts get-caller-identity --query Account --output text', shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            cls._aws_account = result.stdout
+        return cls._aws_account
 
     def openai_label_student_work(self, prompt, rubric, student_code, student_id, examples=[], num_responses=0, temperature=0.0, llm_model="", response_type='tsv'):
         # Determine the OpenAI URL and headers

--- a/lib/assessment/rubric_tester.py
+++ b/lib/assessment/rubric_tester.py
@@ -295,7 +295,7 @@ def main():
     log_level = os.getenv('LOG_LEVEL', 'INFO')
     logging.basicConfig(format='%(asctime)s: %(levelname)s: %(message)s', level=log_level)
 
-    params_directory = os.path.join(os.path.expanduser('~'), "aitt_release_data/")
+    params_directory = os.path.join(os.path.expanduser('~'), "aitt_release_data/release/")
     command_line = " ".join(os.sys.argv)
     options = command_line_options()
     main_start_time = time.time()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pytest-mock==3.12.0
 requests-mock==1.11.0
 coverage==7.3.2
 scikit-learn~=1.3.2
-boto3==1.34.30
+boto3==1.42.85
 esprima==4.0.1

--- a/tests/data/u3l13.txt
+++ b/tests/data/u3l13.txt
@@ -44,7 +44,16 @@ In order to help you evaluate the student's work, you will be given a rubric in 
 
 when choosing a grade for each Key Concept, please follow the following steps:
 1. follow the instructions in the Instructions column from the rubric to generate observations about the student's program. Include the result to the Observations column in your response.
-2. based on those observations, determine the highest grade which accurately describes the student's program. Write this result to the Grade column in your response.
-3. write a reason for your grade in the Reason column, citing evidence from the Observations column when possible.
+2. follow the instructions in the Instructions column from the rubric to generate observations about the student's program. These will be placed in the Evidence column in your response. Observations will include actual lines of code from the student work. These observations are marked by the number of lines of code preceding the actual line of code within the student work. The code and line numbers will precede each observation in the form of this example: "Lines 5-7: The sprite is defined here. `mySprite = createSprite(100, 100);`". You must include the actual code next to the line numbers in the Evidence column in your response. You must include this observed code within backticks in the exact way as the provided example.
+3. based on those observations, provide a step-by-step description of your reasoning to determine the student's grade in the Reason field. The Reason field should end with the text "Decision:" followed by one of the grades Extensive Evidence, Convincing Evidence, Limited Evidence, or No Evidence.
+4. in the Grade field, write only the grade you decided on in the Reason field. To decide on the grade, look only at what follows the text "Decision:" at the end of the Reason field.
 
-Please provide your evaluation formatted as a tab separated values (TSV) table including a header row with column names Key Concept, Observations, Grade, and Reason. There should be one non-header row for each Key Concept.
+Please provide your evaluation formatted as a JSON-encoded array of objects, with one object per Key Concept, where each object has four properties: Key Concept, Observations, Evidence, Reason, and Grade.
+You must include the Grade field, which must be one of the following:
+
+- Extensive Evidence
+- Convincing Evidence
+- Limited Evidence
+- No Evidence
+
+Please always provide your response in JSON format.

--- a/tests/data/u3l23.txt
+++ b/tests/data/u3l23.txt
@@ -41,12 +41,19 @@ to be classified as each of the four possible grades.
 
 when choosing a grade for each Key Concept, please follow the following steps:
 1. follow the instructions in the Instructions column from the rubric to generate observations about the student's program. Include the result to the Observations column in your response.
-2. based on those observations, determine the highest grade which accurately describes the student's program. Write this result to the Grade column in your response.
-3. write a reason for your grade in the Reason column, citing evidence from the Observations column when possible.
+2. follow the instructions in the Instructions column from the rubric to generate observations about the student's program. These will be placed in the Evidence column in your response. Observations will include actual lines of code from the student work. These observations are marked by the number of lines of code preceding the actual line of code within the student work. The code and line numbers will precede each observation in the form of this example: "Lines 5-7: The sprite is defined here. `mySprite = createSprite(100, 100);`". You must include the actual code next to the line numbers in the Evidence column in your response. You must include this observed code within backticks in the exact way as the provided example.
+3. based on those observations, provide a step-by-step description of your reasoning to determine the student's grade in the Reason field. The Reason field should end with the text "Decision:" followed by one of the grades Extensive Evidence, Convincing Evidence, Limited Evidence, or No Evidence.
+4. in the Grade field, write only the grade you decided on in the Reason field. To decide on the grade, look only at what follows the text "Decision:" at the end of the Reason field.
 
-please provide your evaluation formatted as a TSV table including a header row
-with column names Key Concept, Observations, Grade, and Reason. There should be one
-non-header row for each Key Concept.
+Please provide your evaluation formatted as a JSON-encoded array of objects, with one object per Key Concept, where each object has four properties: Key Concept, Observations, Evidence, Reason, and Grade.
+You must include the Grade field, which must be one of the following:
+
+- Extensive Evidence
+- Convincing Evidence
+- Limited Evidence
+- No Evidence
+
+Please always provide your response in JSON format.
 
 The student's work should be evaluated based on what they have added beyond the
 starter code that was provided to them. Here is the starter code:

--- a/tests/routes/test_assessment_routes.py
+++ b/tests/routes/test_assessment_routes.py
@@ -36,6 +36,12 @@ class TestPostAssessment:
             return_value=mock_bedrock_client
         )
 
+        get_aws_account_mock = mocker.patch.object(
+            Label,
+            'get_aws_account',
+            return_value='12345'
+        )
+
         # send the flask request
         os.environ['AIPROXY_API_KEY'] = 'test_key'
         response = client.post(
@@ -67,6 +73,11 @@ class TestPostAssessment:
             'get_bedrock_client',
             return_value=mock_bedrock_client
         )
+        get_aws_account_mock = mocker.patch.object(
+            Label,
+            'get_aws_account',
+            return_value='12345'
+        )
 
         # send the flask request
         request_data = lesson_11_claude_request_data
@@ -89,6 +100,11 @@ class TestPostAssessment:
             Label,
             'get_bedrock_client',
             return_value=mock_bedrock_client
+        )
+        get_aws_account_mock = mocker.patch.object(
+            Label,
+            'get_aws_account',
+            return_value='12345'
         )
 
         # send the flask request
@@ -134,6 +150,11 @@ class TestPostAssessment:
             Label,
             'get_bedrock_client',
             return_value=mock_bedrock_client
+        )
+        get_aws_account_mock = mocker.patch.object(
+            Label,
+            'get_aws_account',
+            return_value='12345'
         )
 
         # send the flask request

--- a/tests/unit/assessment/test_label.py
+++ b/tests/unit/assessment/test_label.py
@@ -1170,6 +1170,11 @@ class TestAiLabelStudentWork:
             'get_bedrock_client',
             return_value=mock_bedrock_client
         )
+        get_aws_account_mock = mocker.patch.object(
+            Label,
+            'get_aws_account',
+            return_value='12345'
+        )
 
         get_response_data_if_valid_mock = mocker.patch.object(
             Label,
@@ -1197,6 +1202,11 @@ class TestAiLabelStudentWork:
             'get_bedrock_client',
             return_value=mock_bedrock_client
         )
+        get_aws_account_mock = mocker.patch.object(
+            Label,
+            'get_aws_account',
+            return_value='12345'
+        )
 
         with pytest.raises(BedrockServerError) as bedrock_error:
             response = label.bedrock_anthropic_label_student_work(prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model='bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0')
@@ -1216,6 +1226,11 @@ class TestAiLabelStudentWork:
             Label,
             'get_bedrock_client',
             return_value=mock_bedrock_client
+        )
+        get_aws_account_mock = mocker.patch.object(
+            Label,
+            'get_aws_account',
+            return_value='12345'
         )
 
         response = label.bedrock_anthropic_label_student_work(prompt, rubric, code, student_id, examples, num_responses, temperature, llm_model='bedrock.anthropic.claude-3-5-sonnet-20240620-v1:0')


### PR DESCRIPTION
## Description
This updates our bedrock model calls to use inference profiles, which are required to call Claude on bedrock. This include necessary CICD updates to allow retrieving the AWS account id and accessing the inference profiles.

## Links
This update is connected to the following PR in aitt_release_data: [Claude 4.5 release](https://github.com/code-dot-org/aitt_release_data/pull/8)

## Testing story
This has been tested manually on our local dev environment and is covered by current unit tests
## Accuracy
Have not been able to assess accuracy changes, since our accuracy testing tools are currently broken due to the required AWS updates. Follow up work will include fixing our accuracy tests and running them for comparison.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->
## API Changes
<!-- 
  Does this code change the API?
-->
## Follow-up work
See Accuracy
## PR Checklist:
<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] Relevant documentation has been added or updated
- [ ] Accuracy against the dev set has been retested
- [ ] Changes in accuracy have been communicated
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
